### PR TITLE
add missing trailing space warning

### DIFF
--- a/js/glotdict-settings.js
+++ b/js/glotdict-settings.js
@@ -28,6 +28,7 @@ function gd_generate_settings_panel() {
 	'no_initial_uppercase': 'No first character uppercase warning on translation',
 	'no_glossary_term_check': 'No glossary term missing warning on translation',
 	'no_non_breaking_space': 'No non-breaking-space in preview',
+	'no_trailing_space': 'No trailing space warning on translation',
 	'curly_apostrophe_warning': 'Add curly apostrophe warning in preview',
 	'hide_info_message': 'Hide Info message about this menu'
   };

--- a/js/glotdict-validation.js
+++ b/js/glotdict-validation.js
@@ -109,6 +109,12 @@ function gd_validate(e, selector) {
 		howmany++;
 	  }
 	}
+	if (!gd_get_setting('no_trailing_space')) {
+	  if ( (lastcharoriginaltext === ' ' && lastcharnewtext !== ' ' ) || (lastcharoriginaltext === ' ' && lastcharnewtext !== ' ' ) ) {
+	    jQuery('.textareas', selector).prepend(gd_get_warning('The translation is missing an ending space or non-breaking space.', discard));
+	    howmany++;
+	  }
+	}
 	if (gd_get_setting('curly_apostrophe_warning')) {
 	  if (newtext.indexOf("'") > -1) {
 		jQuery('.textareas', selector).prepend(gd_get_warning('The translation is using straight apostrophes instead of curly ones. Please check them.', discard));


### PR DESCRIPTION
This introduce missing trailing space warnings.
It supports classic spaces as well as non-breaking space characters.

Related: see https://github.com/GlotPress/GlotPress-WP/issues/863 (GlotPress repo)