### PR TITLE
Highlight non_breaking_space without rendering HTML

### DIFF
--- a/js/glotdict-functions.js
+++ b/js/glotdict-functions.js
@@ -175,17 +175,9 @@ function gd_mark_old_strings() {
 function gd_non_breaking_space_highlight() {
   if (!gd_get_setting('no_non_breaking_space')) {
     jQuery('tr.preview > td.translation.foreign-text, blockquote.translation > em > small').each(function() {
-      var translation_item = jQuery(this).text();
-      if (translation_item.indexOf(' ') > -1) {
-        var translation_highlighted = '';
-        for (var i = 0; i < translation_item.length; i++) {
-          if (translation_item[i] === ' ') {
-            translation_highlighted += '<span style="background-color:yellow"> </span>';
-          } else {
-            translation_highlighted += translation_item[i];
-          }
-        }
-        jQuery(this).html(DOMPurify.sanitize(translation_highlighted));
+      var translation_item = jQuery(this).html();
+      if (translation_item.indexOf('&nbsp;') > -1) {
+        jQuery(this).html(DOMPurify.sanitize(translation_item.replace('&nbsp;', '<span style="background-color:yellow">&nbsp;</span>')));
       }
     });
   }


### PR DESCRIPTION
Fix for #137

This using .html() instead of .text() to load the translation string to highlight non_breaking_spaces without then forcing other HTML in the string to render