### PR TITLE
Add optional warning for non-typographic quotes use (except in HTML attributes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ PS: If you are using NoScript or Privacy Badger enable the domain wordpress.org 
   * First character is not uppercase on translation
   * Missing term translated using the locale glossary
   * Check for curly apostrophe 
+  * Check for non typographic quotes
 * Review mode with a button
 * New column with fast Approve/Reject/Fuzzy for strings
 * Bulk Actions also on footer

--- a/js/glotdict-settings.js
+++ b/js/glotdict-settings.js
@@ -22,6 +22,7 @@ function gd_generate_settings_panel() {
     'no_non_breaking_space': 'Don’t visualize non-breaking-spaces in preview',
     'no_trailing_space': 'Hide warning for trailing space in translation',
     'curly_apostrophe_warning': 'Show warning for missing curly apostrophe in preview'
+    'localized_quote_warning': 'Show warning for using non-typographic quotes in preview (except for HTML attributes quotes)'
   };
   var container = '<div class="notice gd_settings_panel"><h2>GlotDict Settings</h2></div>';
   jQuery('.gp-content').prepend(container);

--- a/js/glotdict-validation.js
+++ b/js/glotdict-validation.js
@@ -117,9 +117,18 @@ function gd_validate(e, selector) {
     }
     if (gd_get_setting('curly_apostrophe_warning')) {
       if (newtext.indexOf("'") > -1) {
-        jQuery('.textareas', selector).prepend(gd_get_warning('The translation is using straight apostrophes instead of curly ones. Please check them.', discard));
+        jQuery('.textareas', selector).prepend(gd_get_warning('The translation is using straight apostrophes instead of curly ones. Please check them against your Locale guidelines.', discard));
         howmany++;
       }
+    }
+    if (gd_get_setting('localized_quote_warning')) {
+      var check_quotes = newtext;
+      check_quotes = check_quotes.replace(/([^>"]*)"(?=[^<]*>)/g, '$1#GDATTR#');
+      if (check_quotes.indexOf('"') > -1) {
+        jQuery('.textareas', selector).prepend(gd_get_warning('The translation is using straight quotes instead of typographic ones. Please check them against your Locale guidelines.', discard));
+        howmany++;
+      }
+      check_quotes = check_quotes.replace(/#GDATTR#/g, '"');
     }
   }
   if (howmany !== 0) {


### PR DESCRIPTION
This is an enhancement regarding item 1 of #149.
Adds a new optional setting to check if there are non typographic quotes in the translation.

JS process:
- add placeholders for quotes which take place inside HTML tags (attributes)
- check if there is remaining quotes
- display the warning
- remove placeholders

Proof of concept: https://codepen.io/audrasjb/pen/BVPVEL?editors=1010