### PR TITLE
Yoast json manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ PS: If you are using NoScript or Privacy Badger enable the domain wordpress.org 
 * Shortcut on Ctrl+Shift+B to "Copy from original"
 * Shortcut on Ctrl+Shift+N to add non-breaking spaces near symbols
 * Shortcut on Ctrl+Alt+R to reset all the GlotDict settings
+* Shortcut on Ctrl+Alt+D to dismiss all the GlotDict validation warning
 * Right click of the mouse on the term with a dashed line and the translation will be added in the translation area
 
 # Download

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ PS: If you are using NoScript or Privacy Badger enable the domain wordpress.org 
 * Shortcut on Ctrl+Shift+B to "Copy from original"
 * Shortcut on Ctrl+Shift+N to add non-breaking spaces near symbols
 * Shortcut on Ctrl+Alt+R to reset all the GlotDict settings
-* Shortcut on Ctrl+Alt+D to dismiss all the GlotDict validation warning
+* Shortcut on Ctrl+Alt+D to dismiss all the GlotDict validation warnings
 * Right click of the mouse on the term with a dashed line and the translation will be added in the translation area
 
 # Download

--- a/js/glotdict-hotkey.js
+++ b/js/glotdict-hotkey.js
@@ -89,4 +89,8 @@ function gd_hotkeys() {
     location.reload();
     return false;
   });
+  key('ctrl+alt+d', function() {
+    jQuery('.discard-glotdict').trigger('click');
+    return false;
+  });
 }

--- a/js/glotdict-settings.js
+++ b/js/glotdict-settings.js
@@ -1,10 +1,4 @@
 jQuery('#menu-headline-nav').append('<li class="current-menu-item gd_setting" style="cursor:pointer;"><a style="font-weight:bold;"> GlotDict</a></li>');
-if (!gd_get_setting('hide_info_message')) {
-  if (jQuery(window).width() > 1390) {
-    jQuery('body').append('<div style="position: absolute;top: 320px;right: 10px;width:200px;background-color: #ddd;padding: .5em;">Don\’t forget to click on the <img class="gd_icon2">GlotDict icon in the blue menu!</div>');
-    jQuery('.gd_icon2').attr('src', jQuery('.gd_icon').attr('src'));
-  }
-}
 jQuery('.gd_icon').prependTo('.gd_setting').show();
 
 jQuery('.gd_setting').click(function() {
@@ -27,8 +21,7 @@ function gd_generate_settings_panel() {
     'no_glossary_term_check': 'Don’t show warning for missing glossary term in translation',
     'no_non_breaking_space': 'Don’t visualize non-breaking-spaces in preview',
     'no_trailing_space': 'Hide warning for trailing space in translation',
-    'curly_apostrophe_warning': 'Show warning for missing curly apostrophe in preview',
-    'hide_info_message': 'Hide Info messages about this menu'
+    'curly_apostrophe_warning': 'Show warning for missing curly apostrophe in preview'
   };
   var container = '<div class="notice gd_settings_panel"><h2>GlotDict Settings</h2></div>';
   jQuery('.gp-content').prepend(container);

--- a/js/glotdict-settings.js
+++ b/js/glotdict-settings.js
@@ -43,6 +43,7 @@ function gd_generate_settings_panel() {
     '<li>Shortcut on Ctrl+Shift+B to "Copy from original"</li>' +
     '<li>Shortcut on Ctrl+Shift+F to add non-breaking spaces near symbols</li>' +
     '<li>Shortcut on Ctrl+Alt+R to reset all the GlotDict settings</li>' +
+    '<li>Shortcut on Ctrl+Alt+D to dismiss all the GlotDict validation warnings</li>' +
     '<li>Right click of the mouse on the term with a dashed line and the translation will be added in the translation area</li>' +
     '</ul><br><h3>Settings</h3>';
   jQuery('.gd_settings_panel').append(hotkeys);

--- a/js/glotdict.js
+++ b/js/glotdict.js
@@ -10,13 +10,6 @@ if (jQuery('.filters-toolbar:last div:first').length > 0) {
   if (jQuery('#bulk-actions-toolbar-top').length > 0) {
     jQuery('#upper-filters-toolbar').css('clear', 'both');
     gd_add_column();
-    jQuery('#bulk-actions-toolbar-top').clone().css('float', 'none').insertBefore('#legend');
-    jQuery('form.filters-toolbar.bulk-actions').submit(function() {
-      var row_ids = jQuery('input:checked', jQuery('table#translations th.checkbox')).map(function() {
-        return jQuery(this).parents('tr.preview').attr('row');
-      }).get().join(',');
-      jQuery('input[name="bulk[row-ids]"]', jQuery(this)).val(row_ids);
-    });
   }
   if (jQuery('.preview').length === 1) {
     jQuery('.preview .action').trigger('click');

--- a/js/glotdict.js
+++ b/js/glotdict.js
@@ -78,3 +78,5 @@ gd_non_breaking_space_highlight();
 gd_wait_table_alter();
 
 gd_remove_layover();
+
+jQuery('.gp-content').css('max-width', '100%');

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
         "css/style.css"
       ],
       "matches": [
-        "*://translate.wordpress.org/*"
+        "*://translate.yoast.com/*"
       ]
     }
   ],


### PR DESCRIPTION
Replace translate.w.org with translate.yoast.com as a base setup to test GlotDict in Yoast GlotPress installation, maybe before allowing GlotDict to work with more GlotPress self hosted installs.