### PR TITLE
Conditionally exclude the bottom toolbar

### DIFF
--- a/js/glotdict.js
+++ b/js/glotdict.js
@@ -10,6 +10,15 @@ if (jQuery('.filters-toolbar:last div:first').length > 0) {
   if (jQuery('#bulk-actions-toolbar-top').length > 0) {
     jQuery('#upper-filters-toolbar').css('clear', 'both');
     gd_add_column();
+    if (jQuery('#bulk-actions-toolbar-bottom').length == 0) {
+      jQuery('#bulk-actions-toolbar-top').clone().css('float', 'none').insertBefore('#legend');
+      jQuery('form.filters-toolbar.bulk-actions').submit(function() {
+        var row_ids = jQuery('input:checked', jQuery('table#translations th.checkbox')).map(function() {
+          return jQuery(this).parents('tr.preview').attr('row');
+        }).get().join(',');
+        jQuery('input[name="bulk[row-ids]"]', jQuery(this)).val(row_ids);
+      });
+    }
   }
   if (jQuery('.preview').length === 1) {
     jQuery('.preview .action').trigger('click');

--- a/js/glotdict.js
+++ b/js/glotdict.js
@@ -10,7 +10,7 @@ if (jQuery('.filters-toolbar:last div:first').length > 0) {
   if (jQuery('#bulk-actions-toolbar-top').length > 0) {
     jQuery('#upper-filters-toolbar').css('clear', 'both');
     gd_add_column();
-    if (jQuery('#bulk-actions-toolbar-bottom').length == 0) {
+    if (jQuery('#bulk-actions-toolbar-bottom').length === 0) {
       jQuery('#bulk-actions-toolbar-top').clone().css('float', 'none').insertBefore('#legend');
       jQuery('form.filters-toolbar.bulk-actions').submit(function() {
         var row_ids = jQuery('input:checked', jQuery('table#translations th.checkbox')).map(function() {


### PR DESCRIPTION
Re-introduced bottom toolbar conditionally when GlotPress version isn't present, this is to support Yoast and other installs and improve on #147