### PR TITLE
Added Count Words functionality

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,6 +24,7 @@
     "gd_wait_table_alter":true,
     "gd_remove_layover":true,
     "gd_add_column":true,
+    "gd_add_meta":true,
     "chrome":true,
     "Promise":true,
     "DOMPurify":true,

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ PS: If you are using NoScript or Privacy Badger enable the domain wordpress.org 
 * Bulk Actions also on footer
 * Mark old string (6 months) with a black border
 * Highlight non-breaking-space
+* Character and Word Counts in Meta
 * Many hotkeys and shortcut
 
 ## Hotkeys

--- a/js/glotdict-column.js
+++ b/js/glotdict-column.js
@@ -59,19 +59,3 @@ function gd_add_column_buttons(element) {
   }
   jQuery(element).append('<td>' + buttons + '</td>');
 }
-
-function gd_wait_table_alter() {
-  if (document.querySelector('#translations tbody') !== null) {
-    var observer = new MutationObserver(function(mutations) {
-      mutations.forEach(function() {
-        gd_add_column();
-      });
-    });
-
-    observer.observe(document.querySelector('#translations tbody'), {
-      attributes: true,
-      childList: true,
-      characterData: true
-    });
-  }
-}

--- a/js/glotdict-column.js
+++ b/js/glotdict-column.js
@@ -11,15 +11,18 @@ function gd_add_column() {
 
 jQuery('#translations').on('click', '.gd-approve', function() {
   $gp.editor.show(jQuery(this));
-  $gp.editor.set_status( jQuery( this ), 'current' ); return false;
+  $gp.editor.set_status( jQuery( this ), 'current' ); 
+  return false;
 });
 jQuery('#translations').on('click', '.gd-reject', function() {
   $gp.editor.show(jQuery(this));
-  $gp.editor.set_status( jQuery( this ), 'rejected' ); return false;
+  $gp.editor.set_status( jQuery( this ), 'rejected' ); 
+  return false;
 });
 jQuery('#translations').on('click', '.gd-fuzzy', function() {
   $gp.editor.show(jQuery(this));
-  $gp.editor.set_status( jQuery( this ), 'fuzzy' ); return false;
+  $gp.editor.set_status( jQuery( this ), 'fuzzy' ); 
+  return false;
 });
 
 function gd_add_column_buttons(element) {

--- a/js/glotdict-functions.js
+++ b/js/glotdict-functions.js
@@ -246,3 +246,25 @@ function gd_add_layover() {
 function gd_remove_layover() {
   jQuery('.gd-layover').remove();
 }
+
+/**
+ * Mutations Observer for Translation Table Changes
+ * 
+ * @triggers gd_add_column, gd_add_meta
+ */
+function gd_wait_table_alter() {
+  if (document.querySelector('#translations tbody') !== null) {
+    var observer = new MutationObserver(function(mutations) {
+      mutations.forEach(function() {
+        gd_add_column();
+        gd_add_meta();
+      });
+    });
+
+    observer.observe(document.querySelector('#translations tbody'), {
+      attributes: true,
+      childList: true,
+      characterData: true
+    });
+  }
+}

--- a/js/glotdict-meta.js
+++ b/js/glotdict-meta.js
@@ -1,0 +1,53 @@
+function gd_add_meta() {
+  jQuery('#translations tr.editor').each(function() { 
+    gd_add_string_counts(this);
+  } );
+}
+
+function gd_add_string_counts(row) {
+    if ( jQuery(row).find('.meta .gd-counts').length ) {
+      jQuery(row).find('.meta .gd-counts').remove();
+    }
+    jQuery(row).find('.meta').append('<div class="gd-counts"><h3>String Counts</h3></div>');
+
+    gd_add_original_count(row);
+
+    if ( jQuery(row).find('.translation').length ) {
+      gd_add_translation_count(row);
+    }
+
+    gd_add_current_count(row);
+
+    jQuery(row).on("change keyup paste", '.textareas textarea.foreign-text', function() {
+      gd_update_current_count(row, this);
+    });
+}
+
+function gd_add_original_count(row) {
+    var originalCharacterCount = jQuery(row).find('.original').text().length;
+    var originalWords = jQuery(row).find('.original').text().split(' ');
+    var originalWordCount = originalWords.length;
+    jQuery(row).find('.gd-counts').append('<dl class="original-count"><dt>Original:</dt><dd><abbr title="' + originalWordCount + ' Words">' + originalCharacterCount + ' Characters</abbr></dd></dl>');
+}
+
+function gd_add_translation_count(row) {
+    var translationCharacterCount = jQuery(row).find('.translation').text().length;
+    var translationWords = jQuery(row).find('.original').text().split(' ');
+    var translationWordCount = translationWords.length;
+    jQuery(row).find('.gd-counts').append('<dl class="translated-count"><dt>Translated</dt><dd><abbr title="' + translationWordCount + ' Words">' + translationCharacterCount + ' Characters</abbr></dd></dl>'); 
+}
+
+function gd_add_current_count(row) {
+    var currentCharacterCount = jQuery(row).find('.textareas textarea.foreign-text').val().length;
+    var currentWords = jQuery(row).find('.textareas textarea.foreign-text').val().split(' ');
+    var currentWordCount = currentWords.length;
+    jQuery(row).find('.gd-counts').append('<dl class="current-count"><dt>Current</dt><dd><abbr title="' + currentWordCount + ' Words">' + currentCharacterCount + ' Characters</abbr></dd></dl>');
+}
+
+function gd_update_current_count(row, textarea) {
+    var currentCharacterCount = jQuery(textarea).val().length;
+    var currentWords = jQuery(row).find('.textareas textarea.foreign-text').val().split(' ');
+    var currentWordCount = currentWords.length;
+    jQuery(row).find('.gd-counts .current-count dd abbr').text(currentCharacterCount + ' Characters');
+    jQuery(row).find('.gd-counts .current-count dd abbr').attr('title', currentWordCount + ' Words');
+}

--- a/js/glotdict-meta.js
+++ b/js/glotdict-meta.js
@@ -1,5 +1,5 @@
 function gd_add_meta() {
-  jQuery('#translations tr.editor').each(function() { 
+  jQuery('#translations tr.editor').each(function() {
     gd_add_string_counts(this);
   } );
 }
@@ -8,7 +8,7 @@ function gd_add_string_counts(row) {
     if ( jQuery(row).find('.meta .gd-counts').length ) {
       jQuery(row).find('.meta .gd-counts').remove();
     }
-    jQuery(row).find('.meta').append('<div class="gd-counts"><h3>String Counts</h3></div>');
+    jQuery(row).find('.meta dl:last-of-type').before('<div class="gd-counts"></div>');
 
     gd_add_original_count(row);
 
@@ -27,27 +27,27 @@ function gd_add_original_count(row) {
     var originalCharacterCount = jQuery(row).find('.original').text().length;
     var originalWords = jQuery(row).find('.original').text().split(' ');
     var originalWordCount = originalWords.length;
-    jQuery(row).find('.gd-counts').append('<dl class="original-count"><dt>Original:</dt><dd><abbr title="' + originalWordCount + ' Words">' + originalCharacterCount + ' Characters</abbr></dd></dl>');
+    jQuery(row).find('.gd-counts').append('<dl class="original-count"><dt>Original String:</dt><dd><span class="characters">' + originalCharacterCount + ' Characters</span> (<span class="words">' + originalWordCount + ' Words</span>)</dd></dl>');
 }
 
 function gd_add_translation_count(row) {
     var translationCharacterCount = jQuery(row).find('.translation').text().length;
     var translationWords = jQuery(row).find('.original').text().split(' ');
     var translationWordCount = translationWords.length;
-    jQuery(row).find('.gd-counts').append('<dl class="translated-count"><dt>Translated</dt><dd><abbr title="' + translationWordCount + ' Words">' + translationCharacterCount + ' Characters</abbr></dd></dl>'); 
+    jQuery(row).find('.gd-counts').append('<dl class="translated-count"><dt>Translated String:</dt><dd><span class="characters">' + translationCharacterCount + ' Characters</span> (<span class="words">' + translationWordCount + ' Words</span>)</dd></dl>');
 }
 
 function gd_add_current_count(row) {
     var currentCharacterCount = jQuery(row).find('.textareas textarea.foreign-text').val().length;
     var currentWords = jQuery(row).find('.textareas textarea.foreign-text').val().split(' ');
     var currentWordCount = currentWords.length;
-    jQuery(row).find('.gd-counts').append('<dl class="current-count"><dt>Current</dt><dd><abbr title="' + currentWordCount + ' Words">' + currentCharacterCount + ' Characters</abbr></dd></dl>');
+    jQuery(row).find('.gd-counts').append('<dl class="current-count"><dt>Current String:</dt><dd><span class="characters">' + currentCharacterCount + ' Characters</span> (<span class="words">' + currentWordCount + ' Words</span>)</dl>');
 }
 
 function gd_update_current_count(row, textarea) {
     var currentCharacterCount = jQuery(textarea).val().length;
     var currentWords = jQuery(row).find('.textareas textarea.foreign-text').val().split(' ');
     var currentWordCount = currentWords.length;
-    jQuery(row).find('.gd-counts .current-count dd abbr').text(currentCharacterCount + ' Characters');
-    jQuery(row).find('.gd-counts .current-count dd abbr').attr('title', currentWordCount + ' Words');
+    jQuery(row).find('.gd-counts .current-count dd .characters').text(currentCharacterCount + ' Characters');
+    jQuery(row).find('.gd-counts .current-count dd .words').text(currentWordCount + ' Words');
 }

--- a/js/glotdict.js
+++ b/js/glotdict.js
@@ -45,6 +45,7 @@ if (jQuery('.filters-toolbar:last div:first').length > 0) {
 
 gd_add_project_links();
 gd_add_button();
+gd_add_meta();
 
 jQuery('.glotdict_language').change(function() {
   localStorage.setItem('gd_language', jQuery('.glotdict_language option:selected').text());
@@ -85,8 +86,6 @@ jQuery('.gp-content').on('click', '.gd-review-done', function(e) {
 gd_non_breaking_space_highlight();
 
 gd_wait_table_alter();
-
-gd_add_meta();
 
 gd_remove_layover();
 

--- a/js/glotdict.js
+++ b/js/glotdict.js
@@ -86,6 +86,8 @@ gd_non_breaking_space_highlight();
 
 gd_wait_table_alter();
 
+gd_add_meta();
+
 gd_remove_layover();
 
 jQuery('.gp-content').css('max-width', '100%');

--- a/js/init.js
+++ b/js/init.js
@@ -1,4 +1,4 @@
-var jsScripts = ['jquery.bind-first', 'dompurify', 'keymaster', 'glotdict-functions', 'glotdict-settings', 'glotdict-hotkey', 'glotdict-validation', 'glotdict-column', 'glotdict-bulk', 'glotdict'];
+var jsScripts = ['jquery.bind-first', 'dompurify', 'keymaster', 'glotdict-functions', 'glotdict-settings', 'glotdict-hotkey', 'glotdict-validation', 'glotdict-column', 'glotdict-meta', 'glotdict-bulk', 'glotdict'];
 
 script(jsScripts);
 

--- a/manifest.json
+++ b/manifest.json
@@ -19,6 +19,7 @@
     "js/glotdict-validation.js",
     "js/glotdict-bulk.js",
     "js/glotdict-column.js",
+    "js/glotdict-meta.js",
     "js/glotdict-settings.js",
     "js/keymaster.js",
     "js/jquery.bind-first.js",


### PR DESCRIPTION
This PR is fixes #112 

It introduces the glotdict-meta.js file for all Meta modifications and adds up to three counts;
- Original
- Translation
- Current
I used abbr to provide both character counts and word counts (on hover).
![string count](https://user-images.githubusercontent.com/8726005/42489957-d21790a0-83c2-11e8-91d1-a769ddf1b6a1.png)