### PR TITLE
Update keybindings for use Ctrl+Shift for all. Fixes #171

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.4.2
+
+* Updated keybindings for consistency. New keybindings; Ctrl+Shift+R to reset all GlotDict settings and Ctrl+Shift+D to dismiss all the validation warnings.
+
 # 1.4.1
 
 * Fix: Approve button on the column wasn't working

--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ PS: If you are using NoScript or Privacy Badger enable the domain wordpress.org 
 * Shortcut on Ctrl+Shift+R to click "Reject"
 * Shortcut on Ctrl+Shift+F to click "Fuzzy"
 * Shortcut on Ctrl+Enter to click "Suggest new translation" or "Add translation"
-* Shortcut on Page Down to open the previous string to translate
-* Shortcut on Page Up to open the next string to translate
 * Shortcut on Ctrl+Shift+B to "Copy from original"
 * Shortcut on Ctrl+Shift+N to add non-breaking spaces near symbols
-* Shortcut on Ctrl+Alt+R to reset all the GlotDict settings
-* Shortcut on Ctrl+Alt+D to dismiss all the validation warnings
+* Shortcut on Ctrl+Shift+R to reset all the GlotDict settings
+* Shortcut on Ctrl+Shift+D to dismiss all the validation warnings
+* Shortcut on Page Down to open the previous string to translate
+* Shortcut on Page Up to open the next string to translate
 * Right click of the mouse on the term with a dashed line and the translation will be added in the translation area
 
 # Download

--- a/js/glotdict-hotkey.js
+++ b/js/glotdict-hotkey.js
@@ -74,24 +74,24 @@ function gd_hotkeys() {
     });
     return false;
   });
-  key('pageup', function() {
-    $gp.editor.prev();
-    return false;
-  });
-  key('pagedown', function() {
-    $gp.editor.next();
-    return false;
-  });
-  key('ctrl+alt+r', function() {
+  key('ctrl+shift+r', function() {
     localStorage.removeItem('gd_language');
     localStorage.removeItem('gd_locales');
     localStorage.removeItem('gd_locales_date');
     location.reload();
     return false;
   });
-  key('ctrl+alt+d', function() {
+  key('ctrl+shift+d', function() {
     jQuery('.discard-glotdict').trigger('click');
     jQuery('.discard-warning').trigger('click');
+    return false;
+  });
+  key('pageup', function() {
+    $gp.editor.prev();
+    return false;
+  });
+  key('pagedown', function() {
+    $gp.editor.next();
     return false;
   });
 }


### PR DESCRIPTION
I've updated the keybindings for consistency.
Minor code re-arrangement and updated the Readme;
* Shortcut on Ctrl+Shift+R to reset all the GlotDict settings
* Shortcut on Ctrl+Shift+D to dismiss all the validation warnings
