### PR TITLE
Improvement of gd_is_uppercase function

### DIFF
--- a/js/glotdict-functions.js
+++ b/js/glotdict-functions.js
@@ -211,7 +211,9 @@ function gd_get_lang_consistency() {
  * @returns {Boolean}
  */
 function gd_is_uppercase(myString) {
-  return (myString === myString.toUpperCase());
+  var lower = myString.toLowerCase();
+  var upper = myString.toUpperCase();
+  return (lower !== upper && myString === upper);
 }
 
 /**


### PR DESCRIPTION
The `gd_is_uppercase` is used to detect an uppercase letter on the original text, so GlotDict can alert translators if the translation does not begin with an uppercase.

The problem : the function doesn't work if original text begins by a character which is identical when it is lowercase and uppercase (like space, parenthesis...).

I modified the function to ignore these characters.