### PR TITLE
Adds a validation for an initial space

### DIFF
--- a/js/glotdict-settings.js
+++ b/js/glotdict-settings.js
@@ -20,6 +20,7 @@ function gd_generate_settings_panel() {
     'no_initial_uppercase': 'Don’t show warning for missing uppercase first character in translation',
     'no_glossary_term_check': 'Don’t show warning for missing glossary term in translation',
     'no_non_breaking_space': 'Don’t visualize non-breaking-spaces in preview',
+    'no_initial_space': 'Hide warning for initial space in translation',
     'no_trailing_space': 'Hide warning for trailing space in translation',
     'curly_apostrophe_warning': 'Show warning for missing curly apostrophe in preview',
     'localized_quote_warning': 'Show warning for using non-typographic quotes in preview (except for HTML attributes quotes)'

--- a/js/glotdict-validation.js
+++ b/js/glotdict-validation.js
@@ -109,6 +109,12 @@ function gd_validate(e, selector) {
         howmany++;
       }
     }
+    if (!gd_get_setting('no_initial_space')) {
+      if ((firstcharoriginaltext === ' ' && firstcharnewtext !== ' ') || (firstcharoriginaltext === ' ' && firstcharnewtext !== ' ')) {
+        jQuery('.textareas', selector).prepend(gd_get_warning('The translation is missing an initial space or non-breaking space.', discard));
+        howmany++;
+      }
+    }
     if (!gd_get_setting('no_trailing_space')) {
       if ((lastcharoriginaltext === ' ' && lastcharnewtext !== ' ') || (lastcharoriginaltext === ' ' && lastcharnewtext !== ' ')) {
         jQuery('.textareas', selector).prepend(gd_get_warning('The translation is missing an ending space or non-breaking space.', discard));


### PR DESCRIPTION
Yes it's me again :)

There is already a validation for ending space but not for initial space. So i added it.

An example of text for testing : https://translate.wordpress.org/projects/wp-plugins/ultimate-member/stable/fr/default?filters%5Boriginal_id%5D=6489512