### PR TITLE
Revert "Remove redundant check"

### DIFF
--- a/js/glotdict-validation.js
+++ b/js/glotdict-validation.js
@@ -110,7 +110,7 @@ function gd_validate(e, selector) {
       }
     }
     if (!gd_get_setting('no_trailing_space')) {
-      if (lastcharoriginaltext === ' ' && lastcharnewtext !== ' ') {
+      if ((lastcharoriginaltext === ' ' && lastcharnewtext !== ' ') || (lastcharoriginaltext === ' ' && lastcharnewtext !== ' ')) {
         jQuery('.textareas', selector).prepend(gd_get_warning('The translation is missing an ending space or non-breaking space.', discard));
         howmany++;
       }


### PR DESCRIPTION
Reverts Mte90/GlotDict#182

My eyes they deceived me. The checks look identical but one checks for a space and the other a non-breaking space.