### PR TITLE
Improve wording for the initial uppercase warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ PS: If you are using NoScript or Privacy Badger enable the domain wordpress.org 
 * More warning on translations
   * Validation for final "...", ".", ":"
   * Validation for final ;.!:、。؟？！
-  * First character is not uppercase on translation
+  * First letter in translation is not uppercase but the original string is
   * Detect first and last character if they are space
   * Missing term translated using the locale glossary
   * Check for curly apostrophe 

--- a/js/glotdict-settings.js
+++ b/js/glotdict-settings.js
@@ -17,13 +17,13 @@ function gd_generate_settings_panel() {
   var settings = {
     'no_final_dot': 'Don’t validate strings ending with “...“, “.”, “:”',
     'no_final_other_dots': 'Don’t validate strings ending with ;.!:、。؟？！',
-    'no_initial_uppercase': 'Don’t show warning for missing uppercase first character in translation',
-    'no_glossary_term_check': 'Don’t show warning for missing glossary term in translation',
+    'no_initial_uppercase': 'Don’t show a warning when the translation doesn\'t contain an initial uppercase letter when the original string starts with one.',
+    'no_glossary_term_check': 'Don’t show a warning when the translation is missing a glossary term.',
     'no_non_breaking_space': 'Don’t visualize non-breaking-spaces in preview',
     'no_initial_space': 'Hide warning for initial space in translation',
     'no_trailing_space': 'Hide warning for trailing space in translation',
-    'curly_apostrophe_warning': 'Show warning for missing curly apostrophe in preview',
-    'localized_quote_warning': 'Show warning for using non-typographic quotes in preview (except for HTML attributes quotes)'
+    'curly_apostrophe_warning': 'Show a warning for missing curly apostrophe in preview',
+    'localized_quote_warning': 'Show a warning for using non-typographic quotes in preview (except for HTML attributes quotes)'
   };
   var container = '<div class="notice gd_settings_panel"><h2>GlotDict Settings</h2></div>';
   jQuery('.gp-content').prepend(container);

--- a/js/glotdict-validation.js
+++ b/js/glotdict-validation.js
@@ -105,7 +105,7 @@ function gd_validate(e, selector) {
     }
     if (!gd_get_setting('no_initial_uppercase')) {
       if (gd_is_uppercase(firstcharoriginaltext) && !gd_is_uppercase(firstcharnewtext)) {
-        jQuery('.textareas', selector).prepend(gd_get_warning('The translation is missing an initial uppercase letter for "<i>' + firstcharnewtext + '</i>"', discard));
+        jQuery('.textareas', selector).prepend(gd_get_warning('The translation is missing an initial uppercase letter as "<i>' + firstcharnewtext + '</i>" is an initial uppercase letter present on the original string.', discard));
         howmany++;
       }
     }


### PR DESCRIPTION
Fixes #183 

I've pushed new verbiage.

Warning - The translation is missing an initial uppercase letter as "<i>' + firstcharnewtext + '</i>" is an initial uppercase letter present on the original string.
Setting - Don’t show a warning when the translation doesn\'t contain an initial uppercase letter when the original string starts with one.
Readme - First letter in translation is not uppercase but the original string is