### PR TITLE
Add autosubmit setting and behaviour to 'Copy from Original' Bulk Action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.4.X
+
+* Added setting to change 'Copy from Original' Bulk Action behaviour to auto-submit selected strings.
+
 # 1.4.3
 
 * Added notices to track counts in real-time for Approved, Rejected, Fuzzied, Submitted and Selected strings

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ PS: If you are using NoScript or Privacy Badger enable the domain wordpress.org 
   * Check for non typographic quotes
 * Review mode with a button
 * New column with fast Approve/Reject/Fuzzy for strings
+* 'Copy from Original' Bulk Action with setting to enable auto-submit.
 * Bulk Actions also on footer
 * Mark old string (6 months) with a black border
 * Highlight non-breaking-space
@@ -43,6 +44,18 @@ PS: If you are using NoScript or Privacy Badger enable the domain wordpress.org 
 * Shortcut on Page Down to open the previous string to translate
 * Shortcut on Page Up to open the next string to translate
 * Right click of the mouse on the term with a dashed line and the translation will be added in the translation area
+
+## Settings
+* Don’t validate strings ending with “...“, “.”, “:”
+* Don’t validate strings ending with ;.!:、。؟？！
+* Don’t show a warning when the translation doesn't contain an initial uppercase letter when the original string starts with one.
+* Don’t show a warning when the translation is missing a glossary term.
+* Don’t visualize non-breaking-spaces in preview
+* Hide warning for initial space in translation
+* Hide warning for trailing space in translation
+* Show a warning for missing curly apostrophe in preview
+* Show a warning for using non-typographic quotes in preview (except for HTML attributes quotes)
+* Auto-submit the "Copy From Original" Bulk Action (Warning: When enabled will submit all originals.)
 
 # Download
 

--- a/css/style.css
+++ b/css/style.css
@@ -6,6 +6,10 @@
 	border-right-width: 2px !important;
 	border-right-color: black !important;
 }
+table.translations tr.preview.has-original-copy, #legend .has-original-copy
+	background: #e5f5fa;
+}
+
 .discard-glotdict{
 	float:right;
 }

--- a/js/glotdict-bulk.js
+++ b/js/glotdict-bulk.js
@@ -6,13 +6,25 @@ jQuery('.bulk-action').append(jQuery('<option>', {
 
 jQuery('.bulk-actions').on('click', '.button', function(e) {
   if (jQuery('.bulk-action option:selected').val() === 'copy-from-original') {
+    var copied_count = 0;
+    $gp.editor.hide(); // Avoid validation on open editors that are empty.
     jQuery('th.checkbox input:checked').each(function() {
       var parent = jQuery(this);
       parent = parent.parent().parent();
       var text = parent.find('.original').text().trim();
       var row = parent.attr('row');
       jQuery('#editor-' + row + ' textarea').val(text);
+      jQuery('#preview-' + row).addClass('has-original-copy');
+      if (gd_get_setting('autosubmit_bulk_copy_from_original')) {
+        jQuery('#editor-' + row + ' button.ok').trigger('click');
+      } else {
+        copied_count++;
+      }
     });
+    if ( copied_count ) {
+      jQuery('#gd-copied-count').remove();
+      jQuery('#translations').before('<div id="gd-copied-count" class="notice copied">' + copied_count + ( copied_count > 1 ? ' originals have ' : ' original has ' ) + 'been copied.</div>');
+    }
     e.preventDefault();
     return false;
   }

--- a/js/glotdict-settings.js
+++ b/js/glotdict-settings.js
@@ -23,7 +23,8 @@ function gd_generate_settings_panel() {
     'no_initial_space': 'Hide warning for initial space in translation',
     'no_trailing_space': 'Hide warning for trailing space in translation',
     'curly_apostrophe_warning': 'Show a warning for missing curly apostrophe in preview',
-    'localized_quote_warning': 'Show a warning for using non-typographic quotes in preview (except for HTML attributes quotes)'
+    'localized_quote_warning': 'Show a warning for using non-typographic quotes in preview (except for HTML attributes quotes)',
+    'autosubmit_bulk_copy_from_original': 'Auto-submit the "Copy From Original" Bulk Action (Warning: When enabled will submit all originals.)'
   };
   var container = '<div class="notice gd_settings_panel"><h2>GlotDict Settings</h2></div>';
   jQuery('.gp-content').prepend(container);

--- a/js/glotdict.js
+++ b/js/glotdict.js
@@ -24,7 +24,9 @@ if (jQuery('.filters-toolbar:last div:first').length > 0) {
     jQuery('.preview .action').trigger('click');
   }
 
-  jQuery("<div class='box has-glotdict'></div><div>Contain a Glossary term</div><div class='box has-old-string'></div><div>The string is at least 6 months old</div>").appendTo('#legend');
+  jQuery("<div class='box has-glotdict'></div><div>Contains a Glossary term</div>").appendTo('#legend');
+  jQuery("<div class='box has-old-string'></div><div>The translation is at least 6 months old</div>").appendTo('#legend');
+  jQuery("<div class='box has-original-copy'></div><div>Contains the Original Copy</div>").appendTo('#legend');
 
   jQuery('.glossary-word').each(function() {
     var $this = jQuery(this);


### PR DESCRIPTION
Adds auto-submit setting and behaviour to the 'Copy from Original' Bulk Action. Default is also improved by highlighting the row light blue to indicate there's copied strings, a legend box is also introduced. A new notice containing the count of the most recent copy action is also added. The auto-submit since it uses default  triggers will also increment the counts on other notices. Addresses #170