### PR TITLE
Added new hotkey Ctrl+Shift+Enter to force submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.4.X
+
+* Feature: New Ctrl+Shift+Enter keybinding to force submission.
+
 # 1.4.3
 
 * Added notices to track counts in real-time for Approved, Rejected, Fuzzied, Submitted and Selected strings

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ PS: If you are using NoScript or Privacy Badger enable the domain wordpress.org 
 ## Hotkeys
 
 * Shortcut on Ctrl+Enter to click "Suggest new translation" or "Add translation"
+* Shortcut on Ctrl+Shift+Enter to double click "Suggest new translation" or "Add translation" to force submission.
 * Shortcut on Ctrl+Shift+Z to click "Cancel"
 * Shortcut on Ctrl+Shift+A to click "Approve"
 * Shortcut on Ctrl+Shift+R to click "Reject"

--- a/js/glotdict-hotkey.js
+++ b/js/glotdict-hotkey.js
@@ -10,6 +10,16 @@ function gd_hotkeys() {
     key.setScope(/^(SELECT)$/.test(tagName) ? 'input' : 'other');
     return true;
   };
+  key('ctrl+shift+enter', function() {
+    if (jQuery('.editor:visible').length > 0) {
+      jQuery('.editor:visible .discard-glotdict').trigger('click');
+      jQuery('.editor:visible .discard-warning').trigger('click');
+      jQuery('.editor:visible .actions button.ok').addClass('forcesubmit').trigger('click');
+    } else {
+      alert('No opened string to add!');
+    }
+    return false;
+  });
   key('ctrl+enter', function() {
     if (jQuery('.editor:visible').length > 0) {
       jQuery('.editor:visible .actions button.ok').trigger('click');

--- a/js/glotdict-settings.js
+++ b/js/glotdict-settings.js
@@ -29,6 +29,7 @@ function gd_generate_settings_panel() {
   jQuery('.gp-content').prepend(container);
   var hotkeys = '<h3>Hotkeys</h3><ul>' +
     '<li>Shortcut on Ctrl+Enter to click "Suggest new translation" or "Add translation"</li>' +
+    '<li>Shortcut on Ctrl+Shift+Enter to double click "Suggest new translation" or "Add translation" to force submission.</li>' +
     '<li>Shortcut on Ctrl+Shift+Z to click "Cancel"</li>' +
     '<li>Shortcut on Ctrl+Shift+A to click "Approve"</li>' +
     '<li>Shortcut on Ctrl+Shift+R to click "Reject"</li>' +

--- a/js/glotdict.js
+++ b/js/glotdict.js
@@ -40,7 +40,7 @@ if (jQuery('.filters-toolbar:last div:first').length > 0) {
 
   gd_locales_selector();
 
-  jQuery($gp.editor.table).onFirst('click', 'button.ok', gd_validate_visible);
+  jQuery($gp.editor.table).onFirst('click', 'button.ok:not(.forcesubmit)', gd_validate_visible);
 }
 
 gd_add_project_links();


### PR DESCRIPTION
This will remove existing warnings prior to adding a .forcesubmit class to the button so as to bypass the button validation trigger. Addresses #178.