### PR TITLE
Replace ignoreList with default GP copy trigger

### DIFF
--- a/js/glotdict-bulk.js
+++ b/js/glotdict-bulk.js
@@ -9,22 +9,9 @@ jQuery('.bulk-actions').on('click', '.button', function(e) {
     var copied_count = 0;
     $gp.editor.hide(); // Avoid validation on open editors that are empty.
     jQuery('th.checkbox input:checked').each(function() {
-
-      // List of selectors to ignore
-      var ignoreList = [
-        // any valid selector
-        '.context'
-      ];
       var parent = jQuery(this).closest('tr');
-      
-      // Copy element which will be modified
-      var workingElement = parent.find('.original').clone();
-        
-      // Remove all the elements we don't need
-      workingElement.find(ignoreList.join()).remove();
-      var text = workingElement.text().trim();
       var row = parent.attr('row');
-      jQuery('#editor-' + row + ' textarea').val(text);
+      jQuery('#editor-' + row + ' .copy').trigger('click');
       jQuery('#preview-' + row).addClass('has-original-copy');
       if (gd_get_setting('autosubmit_bulk_copy_from_original')) {
         jQuery('#editor-' + row + ' button.ok').trigger('click');


### PR DESCRIPTION
After reviewing the 'Copy from Original' bulk implementation I realized we overthought it and didn't need to have an ignoreList or anything if we just triggered the default GlotPress copy actions.