### PR TITLE
Add warning handling into Glotdict to flag and discard warnings.

### DIFF
--- a/js/glotdict-validation.js
+++ b/js/glotdict-validation.js
@@ -1,6 +1,6 @@
 /**
  * Run the review
- * 
+ *
  * @returns void
  */
 function gd_run_review() {
@@ -13,9 +13,6 @@ function gd_run_review() {
     var howmany = gd_validate('', editor);
     if (howmany > 0) {
       review_error_count += howmany;
-      $preview.find('.checkbox').css({
-        'background': 'red'
-      });
     }
     review_count++;
   });
@@ -30,10 +27,10 @@ function gd_run_review() {
 
 /**
  * Check if in the translations there aren't the translation suggested
- * 
+ *
  * @param {object} e The event.
  * @param {object} selector The selector.
- * 
+ *
  * @returns void
  */
 function gd_search_glossary_on_translation(e, selector) {
@@ -79,7 +76,7 @@ function gd_search_glossary_on_translation(e, selector) {
 
 /**
  * Validation is good to save time!
- * 
+ *
  * @param {object} e The event.
  * @param {string} selector The selector.
  *
@@ -155,6 +152,9 @@ function gd_validate(e, selector) {
     }
   }
   if (howmany !== 0) {
+    jQuery(selector).removeClass('no-warnings').addClass('has-warnings');
+    var previewSelector = '#preview-' + jQuery(selector).attr('row');
+    jQuery(previewSelector).removeClass('no-warnings').addClass('has-warnings');
     gd_stoppropagation(e);
   }
   return howmany;
@@ -181,7 +181,7 @@ function gd_validate_visible(e) {
 
 /**
  * Get the discard link
- * 
+ *
  * @param {String} selector
  * @returns {String}
  */
@@ -191,7 +191,7 @@ function gd_get_discard_link(selector) {
 
 /**
  * Get the warning link
- * 
+ *
  * @param {String} text
  * @param {String} discard
  * @returns {String}

--- a/js/glotdict.js
+++ b/js/glotdict.js
@@ -71,6 +71,10 @@ jQuery('.gp-content').on('click', '.discard-glotdict', function(e) {
   if (jQuery('#editor-' + row + ' .gd-warning').length === 0) {
     jQuery.removeData('#editor-' + row, 'discard');
   }
+  if (jQuery('#editor-' + row + ' .warning').length === 0) {
+    jQuery('#editor-' + row).removeClass('has-warnings').addClass('no-warnings');
+    jQuery('#preview-' + row).removeClass('has-warnings').addClass('no-warnings');
+  }
   e.preventDefault();
   return false;
 });


### PR DESCRIPTION
Add .(has|no)-warnings class handling on validation and discard. Updates the review to drop the custom red bg and instead use the .has-warnings class and styling. This covers reviews, mass copy from original and individual submission handling of warnings.