### PR TITLE
Improved Bulk Copy w/ Autosubmit & Force Autosubmit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 * Feature: Added setting to change 'Copy from Original' Bulk Action behaviour to auto-submit selected strings.
 * Enhancement: Improve Review Process to provide a notice with error and row counts as well as a complete state.
 * Fix: Ignore the context label on Copy from original
+* Fix: Introduce delay in "Copy From Original" when autosubmitting to avoid RACE conditions.
+* Enhancement: Added setting to allow bypassing validating during the "Copy From Original" Bulk Action.
 
 # 1.4.3
 

--- a/README.md
+++ b/README.md
@@ -51,12 +51,13 @@ PS: If you are using NoScript or Privacy Badger enable the domain wordpress.org 
 * Don’t validate strings ending with ;.!:、。؟？！
 * Don’t show a warning when the translation doesn't contain an initial uppercase letter when the original string starts with one.
 * Don’t show a warning when the translation is missing a glossary term.
-* Don’t visualize non-breaking-spaces in preview
-* Hide warning for initial space in translation
-* Hide warning for trailing space in translation
-* Show a warning for missing curly apostrophe in preview
-* Show a warning for using non-typographic quotes in preview (except for HTML attributes quotes)
-* Auto-submit the "Copy From Original" Bulk Action (Warning: When enabled will submit all originals.)
+* Don’t visualize non-breaking-spaces in preview.
+* Hide warning for initial space in translation.
+* Hide warning for trailing space in translation.
+* Show a warning for missing curly apostrophe in preview.
+* Show a warning for using non-typographic quotes in preview (except for HTML attributes quotes).
+* Auto-submit the "Copy From Original" Bulk Action (Warning: When enabled will submit all originals).
+* Don’t validate strings during "Copy From Original" Bulk Action to bypass validation. (Warning: When enabled will submit originals with Glossary terms or other warnings.)
 
 # Download
 

--- a/js/glotdict-bulk.js
+++ b/js/glotdict-bulk.js
@@ -1,4 +1,3 @@
-
 jQuery('.bulk-action').append(jQuery('<option>', {
   value: 'copy-from-original',
   text: 'Copy From Original'
@@ -7,24 +6,40 @@ jQuery('.bulk-action').append(jQuery('<option>', {
 jQuery('.bulk-actions').on('click', '.button', function(e) {
   if (jQuery('.bulk-action option:selected').val() === 'copy-from-original') {
     var copied_count = 0;
+    var timeout = 0;
     $gp.editor.hide(); // Avoid validation on open editors that are empty.
     jQuery('th.checkbox input:checked').each(function() {
-      var parent = jQuery(this).closest('tr');
+      var checkbox = jQuery(this);
+      var parent = checkbox.closest('tr');
       var row = parent.attr('row');
-      jQuery('#editor-' + row + ' .copy').trigger('click');
-      jQuery('#preview-' + row).addClass('has-original-copy');
       if (gd_get_setting('autosubmit_bulk_copy_from_original')) {
-        jQuery('#editor-' + row + ' button.ok').trigger('click');
+        setTimeout( function(){
+          $gp.editor.show(checkbox);
+          jQuery('#editor-' + row + ' .copy').trigger('click');
+          jQuery('#preview-' + row).addClass('has-original-copy');
+          if (gd_get_setting('force_autosubmit_bulk_copy_from_original')) {
+            jQuery('#editor-' + row + ' button.ok').addClass('forcesubmit');
+          }
+          jQuery('#editor-' + row + ' button.ok').trigger('click');
+          copied_count++;
+          gd_copied_count_notice(copied_count);
+        }, timeout);
+        timeout += 2000;
       } else {
+        jQuery('#editor-' + row + ' .copy').trigger('click');
+        jQuery('#preview-' + row).addClass('has-original-copy');
         copied_count++;
+        gd_copied_count_notice(copied_count);
       }
     });
-    if ( copied_count ) {
-      jQuery('#gd-copied-count').remove();
-      jQuery('#translations').before('<div id="gd-copied-count" class="notice copied">' + copied_count + ( copied_count > 1 ? ' originals have ' : ' original has ' ) + 'been copied.</div>');
-    }
     e.preventDefault();
     return false;
   }
 });
 
+function gd_copied_count_notice(count) {
+  if ( count ) {
+    jQuery('#gd-copied-count').remove();
+    jQuery('#translations').before('<div id="gd-copied-count" class="notice copied">' + count + ( count > 1 ? ' originals have ' : ' original has ' ) + 'been copied.</div>');
+  }
+}

--- a/js/glotdict-notices.js
+++ b/js/glotdict-notices.js
@@ -108,7 +108,7 @@ jQuery(document).on('click', '.checkbox :checkbox', function(e) {
       }
       glotdict_string_text += ' with Glossary terms';
       selected_strings_text.push(glotdict_string_text);
-    }    
+    }
     jQuery('#translations').before('<div id="gd-checked-count" class="notice">' + checked_count + ( checked_count > 1 ? ' rows are ' : ' row is ' ) + ' selected.</div>');
     if (Array.isArray(selected_strings_text) && selected_strings_text.length > 0) {
       jQuery('#gd-checked-count').append(' (' + selected_strings_text.join(', ') + '.)');

--- a/js/glotdict-settings.js
+++ b/js/glotdict-settings.js
@@ -19,12 +19,13 @@ function gd_generate_settings_panel() {
     'no_final_other_dots': 'Don’t validate strings ending with ;.!:、。؟？！',
     'no_initial_uppercase': 'Don’t show a warning when the translation doesn\'t contain an initial uppercase letter when the original string starts with one.',
     'no_glossary_term_check': 'Don’t show a warning when the translation is missing a glossary term.',
-    'no_non_breaking_space': 'Don’t visualize non-breaking-spaces in preview',
-    'no_initial_space': 'Hide warning for initial space in translation',
-    'no_trailing_space': 'Hide warning for trailing space in translation',
-    'curly_apostrophe_warning': 'Show a warning for missing curly apostrophe in preview',
-    'localized_quote_warning': 'Show a warning for using non-typographic quotes in preview (except for HTML attributes quotes)',
-    'autosubmit_bulk_copy_from_original': 'Auto-submit the "Copy From Original" Bulk Action (Warning: When enabled will submit all originals.)'
+    'no_non_breaking_space': 'Don’t visualize non-breaking-spaces in preview.',
+    'no_initial_space': 'Hide warning for initial space in translation.',
+    'no_trailing_space': 'Hide warning for trailing space in translation.',
+    'curly_apostrophe_warning': 'Show a warning for missing curly apostrophe in preview.',
+    'localized_quote_warning': 'Show a warning for using non-typographic quotes in preview (except for HTML attributes quotes).',
+    'autosubmit_bulk_copy_from_original': 'Auto-submit the "Copy From Original" Bulk Action (Warning: When enabled will submit all originals).',
+    'force_autosubmit_bulk_copy_from_original': 'Don’t validate strings during "Copy From Original" Bulk Action to bypass validation. (Warning: When enabled will submit originals with Glossary terms or other warnings.)'
   };
   var container = '<div class="notice gd_settings_panel"><h2>GlotDict Settings</h2></div>';
   jQuery('.gp-content').prepend(container);

--- a/js/glotdict-validation.js
+++ b/js/glotdict-validation.js
@@ -161,6 +161,7 @@ function gd_validate(e, selector) {
 }
 
 function gd_validate_visible(e) {
+  if (jQuery(this).hasClass('forcesubmit')) return;
   var selector = '.editor:visible';
   var howmany = gd_validate(e, selector);
   if (typeof howmany !== 'undefined' && howmany !== 0) {


### PR DESCRIPTION
Improved the Bulk Copy action to support additional settings to autosubmit as well as force autosubmit. Adds a new copied count notice. When autosubmit enabled but force autosubmit isn't then the warning rows will get flagged but won't submit.