### PR TITLE
177 plural string counts

### DIFF
--- a/js/glotdict-bulk.js
+++ b/js/glotdict-bulk.js
@@ -16,6 +16,7 @@ jQuery('.bulk-actions').on('click', '.button', function(e) {
         setTimeout( function(){
           $gp.editor.show(checkbox);
           jQuery('#editor-' + row + ' .copy').trigger('click');
+          jQuery('#editor-' + row + ' textarea.foreign-text').trigger('change');
           jQuery('#preview-' + row).addClass('has-original-copy');
           if (gd_get_setting('force_autosubmit_bulk_copy_from_original')) {
             jQuery('#editor-' + row + ' button.ok').addClass('forcesubmit');
@@ -27,6 +28,7 @@ jQuery('.bulk-actions').on('click', '.button', function(e) {
         timeout += 2000;
       } else {
         jQuery('#editor-' + row + ' .copy').trigger('click');
+        jQuery('#editor-' + row + ' textarea.foreign-text').trigger('change');
         jQuery('#preview-' + row).addClass('has-original-copy');
         copied_count++;
         gd_copied_count_notice(copied_count);


### PR DESCRIPTION
Added support for plural strings (including multi-plural locales).

Showing when Singular + Plural;
<img width="313" alt="screen shot 2018-11-05 at 12 57 03 am" src="https://user-images.githubusercontent.com/8726005/47989328-87eeea80-e099-11e8-9bf4-e7389e7352c7.png">

Showing when Multi-Plural Locale;
<img width="377" alt="screen shot 2018-11-05 at 12 57 08 am" src="https://user-images.githubusercontent.com/8726005/47989353-9806ca00-e099-11e8-81ec-29f0c163d5a7.png">
*Although the length is quite long on multi-plural locales, they have very long editor columns due to the multiple textareas so things balance out.

Also fixed the issue with copy from original not updating the counts.