### PR TITLE
Quick Fix for counts to avoid counting the thead checkbox

### DIFF
--- a/js/glotdict-bulk.js
+++ b/js/glotdict-bulk.js
@@ -8,7 +8,7 @@ jQuery('.bulk-actions').on('click', '.button', function(e) {
     var copied_count = 0;
     var timeout = 0;
     $gp.editor.hide(); // Avoid validation on open editors that are empty.
-    jQuery('th.checkbox input:checked').each(function() {
+    jQuery('tbody th.checkbox input:checked').each(function() {
       var checkbox = jQuery(this);
       var parent = checkbox.closest('tr');
       var row = parent.attr('row');


### PR DESCRIPTION
This is a quick fix to the copied_count logic isolating it to the tbody so it doesn't affect/count the thead checkbox.