### PR TITLE
fix rows opened by buttons

### DIFF
--- a/js/glotdict-column.js
+++ b/js/glotdict-column.js
@@ -17,6 +17,9 @@ function gd_add_column_buttons(element) {
     clone_button.classList.add('gd-' + clone_button.classList[0]);
     clone_button.addEventListener('click', function(e) {
       var button = e.target;
+      button.disabled = true;
+      button.style.color = '#afafaf';
+      button.querySelector('strong').classList.add('gd-btn-action');
       var editor = button.closest('tr.preview').nextElementSibling;
       var new_status = button.classList[0];
       new_status = new_status === 'approve' ? 'current' : new_status;
@@ -24,7 +27,7 @@ function gd_add_column_buttons(element) {
       $gp.editor.show(jQuery(button));
       $gp.editor.set_status(jQuery(button), new_status);
       editor.style.display = 'none';
-      $gp.editor.show(jQuery(button));
+      button.closest('tr.preview').style.display = 'table-row';
     });
     if (!element.classList.contains('untranslated')) {
       td_buttons.append(clone_button);

--- a/js/glotdict-functions.js
+++ b/js/glotdict-functions.js
@@ -112,7 +112,7 @@ function gd_add_button() {
   if (window.location.href === 'https://translate.wordpress.org/stats/') {
     jQuery('.gp-content').prepend('<button style="float:right" class="gd_scroll">Scroll to ' + gd_get_lang() + '</button>');
     jQuery('.gd_scroll').on('click', function() {
-      var row = jQuery("#stats-table tr th a").filter(function() { return jQuery(this).html().trim() === gd_get_lang(); } );
+      var row = jQuery('#stats-table tr th a').filter(function() { return jQuery(this).html().trim() === gd_get_lang(); });
       row.html('<b>&nbsp;&nbsp;&nbsp;' + row.text() + '</b>');
       jQuery('html, body').animate({
         scrollTop: row.offset().top - 50
@@ -144,7 +144,6 @@ function gd_locales_selector() {
   if (lang === '' || lang === false) {
     window.gd_filter_bar.append('<h3 style="background-color:#ddd;padding:4px;width:130px;display:inline;margin-left:4px;color:red;">&larr; Set the glossary!</h3>')
       .append('<br><h2 style="background-color:#fff;padding:0;display:block;text-align:center;margin-top: 6px;">Welcome to GlotDict! Discover the features and the hotkeys on the <a href="https://github.com/Mte90/GlotDict/blob/master/README.md#features"  target="_blank" rel="noreferrer noopener">Readme</a>.</h2>');
-    return;
   }
 }
 
@@ -274,8 +273,24 @@ function gd_remove_layover() {
 function gd_wait_table_alter() {
   if (document.querySelector('#translations tbody') !== null) {
     var observer = new MutationObserver(function(mutations) {
-      mutations.forEach(function() {
-        gd_add_column();
+      mutations.forEach(function(mutation) {
+        if (document.querySelector('#bulk-actions-toolbar-top') === null) {
+          return;
+        }
+        mutation.addedNodes.forEach(function(addedNode) {
+          if (addedNode.nodeType !== 1) {
+            return;
+          }
+          if (addedNode.classList.contains('editor') && mutation.previousSibling && !mutation.previousSibling.matches('.editor.untranslated')) {
+            var next_row_editor = addedNode.nextElementSibling.nextElementSibling;
+            var next_row_preview = next_row_editor.previousElementSibling;
+            next_row_editor.style.display = 'none';
+            next_row_preview.style.display = 'table-row';
+          }
+          if (addedNode.classList.contains('preview')) {
+            gd_add_column_buttons(addedNode);
+          }
+        });
         gd_add_meta();
       });
     });


### PR DESCRIPTION
A behavior has changed with last modifications on buttons:
Actions work well (Reject, Approve, Fuzzy) but they open the next row like originals GlotPress buttons do.

So I made some small changes:
First, I used the mutations observer to close the next row.
Then, since we have the element targeted by the mutation, I pass it to gd_add_column_buttons to avoid to process all the rows.
Finally, I slightly modified the style of the button which is clicked for the duration of the click, because the action being done more quickly, one could have the impression that nothing was happening. Among other things, I added a rotation on the sign of the button.
As a video is more explicit: https://www.dropbox.com/s/f1qgut3k5o1gekc/betterbuttons.mp4?dl=0
