### PR TITLE
fix js error when action is blocked and add css animation

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -80,3 +80,20 @@ table.translations tr.preview.has-original-copy, #legend .has-original-copy {
 	background: #e44b3e;
 	border-left: 3px solid #dc3232;
 }
+button[class*="gd-"] strong {
+	display: inline-block;
+}
+.gd-btn-action {
+	animation: gd-rotation 2s infinite linear;
+}
+button.gd-approve strong {
+	transform-origin: 51% 49%;
+}
+@keyframes gd-rotation {
+	from {
+		transform: rotate(0deg);
+	}
+	to {
+		transform: rotate(359deg);
+	}
+}

--- a/js/glotdict-column.js
+++ b/js/glotdict-column.js
@@ -17,16 +17,22 @@ function gd_add_column_buttons(element) {
     clone_button.classList.add('gd-' + clone_button.classList[0]);
     clone_button.addEventListener('click', function(e) {
       var button = e.target;
+      if (!button) { return; }
       button.disabled = true;
       button.style.color = '#afafaf';
-      button.querySelector('strong').classList.add('gd-btn-action');
+      var strong = button.querySelector('strong');
+      if (strong) {
+        button.querySelector('strong').classList.add('gd-btn-action');
+      }
       var editor = button.closest('tr.preview').nextElementSibling;
       var new_status = button.classList[0];
       new_status = new_status === 'approve' ? 'current' : new_status;
       new_status = new_status === 'reject' ? 'rejected' : new_status;
       $gp.editor.show(jQuery(button));
       $gp.editor.set_status(jQuery(button), new_status);
-      editor.style.display = 'none';
+      if (editor) {
+        editor.style.display = 'none';
+      }
       button.closest('tr.preview').style.display = 'table-row';
     });
     if (!element.classList.contains('untranslated')) {

--- a/js/glotdict-functions.js
+++ b/js/glotdict-functions.js
@@ -284,6 +284,7 @@ function gd_wait_table_alter() {
           if (addedNode.classList.contains('editor') && mutation.previousSibling && !mutation.previousSibling.matches('.editor.untranslated')) {
             var next_row_editor = addedNode.nextElementSibling.nextElementSibling;
             var next_row_preview = next_row_editor.previousElementSibling;
+            if (!next_row_editor || !next_row_preview) { return; }
             next_row_editor.style.display = 'none';
             next_row_preview.style.display = 'table-row';
           }


### PR DESCRIPTION
Addition of checks on the existence of the Nodes used:
it happens (fortunately very rarely) that a POST request does not pass immediately when rejecting / approving / fuzzy successively and quickly. It still passes just after with a delay of half a second.
![image](https://user-images.githubusercontent.com/17084006/101629844-3e182180-3a22-11eb-9fbf-1542ed888069.png)
The user sees a warning but the action is done anyway. 
And in this case, a JS error appeared in the web console. This error will no longer appear.
Addition of a CSS animation on the sign displayed on the clicked button to visualize the processing and not believe that nothing is happening.
This pull request fixes something that does not prevent processing.

