### PR TITLE
Add scroll buttons to locales on all projects tables

### DIFF
--- a/js/glotdict-functions.js
+++ b/js/glotdict-functions.js
@@ -121,7 +121,8 @@ function gd_add_review_button() {
 function gd_add_scroll_buttons() {
   var locations = {
     statsRegex: 'https:\\/\\/translate.wordpress.org\\/stats\\/$',
-    projectsRegex: 'https:\\/\\/translate.wordpress.org\\/projects\\/[^\\/]+\\/[^\\/]+\\/$'
+    projectsRegex: 'https:\\/\\/translate.wordpress.org\\/projects\\/[^\\/]+\\/[^\\/]+\\/$',
+    appsRegex: 'https:\\/\\/translate.wordpress.org\\/projects\\/apps\\/[^\\/]+\\/[^\\/]+\\/$'
   }
 
   var locale = gd_get_lang().toLowerCase().replace('_', '-').split('-');

--- a/js/glotdict-functions.js
+++ b/js/glotdict-functions.js
@@ -105,22 +105,49 @@ function gd_add_project_links() {
 }
 
 /**
- * Add the button to scroll to the row of the language choosen
+ * Add the review button
  * @returns void
  */
-function gd_add_button() {
-  if (window.location.href === 'https://translate.wordpress.org/stats/') {
-    jQuery('.gp-content').prepend('<button style="float:right" class="gd_scroll">Scroll to ' + gd_get_lang() + '</button>');
-    jQuery('.gd_scroll').on('click', function() {
-      var row = jQuery('#stats-table tr th a').filter(function() { return jQuery(this).html().trim() === gd_get_lang(); });
-      row.html('<b>&nbsp;&nbsp;&nbsp;' + row.text() + '</b>');
-      jQuery('html, body').animate({
-        scrollTop: row.offset().top - 50
-      });
-    });
-  }
+function gd_add_review_button() {
   if (jQuery('body.logged-in').length !== 0) {
     jQuery('.filters-toolbar.bulk-actions:first div:last').append(' <input class="button gd-review" value="Review" type="button">');
+  }
+}
+
+/**
+ * Add the buttons to scroll to the row of the language choosen
+ * @returns void
+ */
+function gd_add_scroll_buttons() {
+  var locations = {
+    statsRegex: 'https:\\/\\/translate.wordpress.org\\/stats\\/$',
+    projectsRegex: 'https:\\/\\/translate.wordpress.org\\/projects\\/[^\\/]+\\/[^\\/]+\\/$'
+  }
+
+  var locale = gd_get_lang().toLowerCase().replace('_', '-').split('-');
+  var slug = (!locale[1] || locale[0] === locale[1]) ? locale[0] : locale[0] + '-' + locale[1];
+
+  for (var regex in locations) {
+    var position = document.querySelector('table');
+    var acquired = (RegExp(locations[regex])).test(window.location.href);
+    if (position && acquired) {
+      jQuery(position).before('<button style="float:right;margin-bottom:1em" class="gd_scroll">Scroll to ' + gd_get_lang() + '</button>');
+
+      jQuery('.gd_scroll').on('click', function() {
+        var target = document.querySelector('table tr th a[href*="/' + slug + '/"]') || document.querySelector('table td strong a[href*="/' + slug + '/"]');
+        if (!target) { return; }
+        var row = target.closest('tr');
+        if (!row) { return; }
+        row.style.border = '2px solid black';
+        target.style.color = '#a70505';
+        if (!target.textContent.includes('➤')) {
+          target.textContent = '➤ ' + target.textContent;
+        }
+        jQuery('html, body').animate({
+          scrollTop: jQuery(row).offset().top - 70
+        });
+      });
+    }
   }
 }
 

--- a/js/glotdict.js
+++ b/js/glotdict.js
@@ -50,7 +50,8 @@ if (window.gd_filter_bar.length > 0) {
 }
 
 gd_add_project_links();
-gd_add_button();
+gd_add_review_button();
+gd_add_scroll_buttons();
 gd_add_meta();
 
 jQuery('.glotdict_language').change(function() {


### PR DESCRIPTION
Issue https://github.com/Mte90/GlotDict/issues/223

The process is based on 3 regex concerning URLs: the first to manage the button that already existed on the global stats page, the second to manage all the projects (therefore themes and plugins but also all others), and the third to manage Apps that have a sub-level.
The search is done on the HTML `<table>` tag and no longer on a class or an ID since there is only one table on the URLs tracked by the regex and **the target must also be good**.
The target is no longer the locale but the locale-based slug.
`fr_FR` will give `/fr/`
`fr_BE` will give `/fr-be/`
`ast` will give `/ast/`
The target is assigned an arrow and a color to spot it.

![buttons](https://user-images.githubusercontent.com/17084006/101978452-58861100-3c55-11eb-9b1b-43654d0ff944.gif)
