### PR TITLE
fix js error on mutation observer & remove tabindex on buttons

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -84,17 +84,31 @@ button[class*="gd-"] strong {
 	display: inline-block;
 }
 .gd-btn-action {
-	animation: gd-rotation 2s infinite linear;
+	-webkit-animation: gd-rotation 2s infinite linear;
+	        animation: gd-rotation 2s infinite linear;
 }
 button.gd-approve strong {
-	transform-origin: 51% 49%;
+	-webkit-transform-origin: 51% 49%;
+	        transform-origin: 51% 49%;
+}
+@-webkit-keyframes gd-rotation {
+	from {
+		-webkit-transform: rotate(0deg);
+		        transform: rotate(0deg);
+	}
+	to {
+		-webkit-transform: rotate(359deg);
+		        transform: rotate(359deg);
+	}
 }
 @keyframes gd-rotation {
 	from {
-		transform: rotate(0deg);
+		-webkit-transform: rotate(0deg);
+		        transform: rotate(0deg);
 	}
 	to {
-		transform: rotate(359deg);
+		-webkit-transform: rotate(359deg);
+		        transform: rotate(359deg);
 	}
 }
 .gd-locale-moved {

--- a/js/glotdict-column.js
+++ b/js/glotdict-column.js
@@ -13,16 +13,17 @@ function gd_add_column_buttons(tr_preview) {
   var td_buttons = document.createElement('TD');
   tr_preview.append(td_buttons);
   tr_preview.nextElementSibling.querySelectorAll('.meta button').forEach(function(button) {
+    button.removeAttribute('tabindex');
     var clone_button = button.cloneNode(true);
     clone_button.classList.add('gd-' + clone_button.classList[0]);
     clone_button.addEventListener('click', function(e) {
       var button = (e.target.parentElement.nodeName === 'BUTTON') ? e.target.parentElement : e.target;
       if (!button) { return; }
+      var strong = button.querySelector('strong');
       button.disabled = true;
       button.style.color = '#afafaf';
-      var strong = button.querySelector('strong');
       if (strong) {
-        button.querySelector('strong').classList.add('gd-btn-action');
+        strong.classList.add('gd-btn-action');
       }
       var editor = button.closest('tr.preview').nextElementSibling;
       var new_status = button.classList[0];

--- a/js/glotdict-functions.js
+++ b/js/glotdict-functions.js
@@ -338,7 +338,29 @@ function gd_current_locale_first() {
 }
 
 /**
- * Mutations Observer for Translation Table Changes
+ * Auto hide next editor when status action open it.
+ *
+ * @param {object} editor
+ * @returns {void}
+ */
+function gd_auto_hide_next_editor(editor) {
+  var preview = editor.nextElementSibling;
+  if (!preview) {
+    return;
+  }
+  var next_editor = preview.nextElementSibling;
+  var next_preview = next_editor.previousElementSibling;
+  if (!next_editor || !next_preview || !next_editor.classList.contains('editor') || !next_preview.classList.contains('preview')) {
+    return;
+  }
+  next_editor.style.display = 'none';
+  next_preview.style.display = 'table-row';
+}
+
+/**
+ * Mutations Observer for Translation Table Changes:
+ * Auto hide next editor on status actions.
+ * Add clone buttons on new preview rows.
  *
  * @triggers gd_add_column, gd_add_meta
  */
@@ -354,11 +376,7 @@ function gd_wait_table_alter() {
             return;
           }
           if (addedNode.classList.contains('editor') && mutation.previousSibling && !mutation.previousSibling.matches('.editor.untranslated')) {
-            var next_row_editor = addedNode.nextElementSibling.nextElementSibling;
-            var next_row_preview = next_row_editor.previousElementSibling;
-            if (!next_row_editor || !next_row_preview) { return; }
-            next_row_editor.style.display = 'none';
-            next_row_preview.style.display = 'table-row';
+            gd_auto_hide_next_editor(addedNode);
           }
           if (addedNode.classList.contains('preview')) {
             gd_add_column_buttons(addedNode);


### PR DESCRIPTION
Fix js error on mutation observer by refactoring gd_wait_table_alter function.
Add prefix for CSS animations on buttons.
Remove tabindex attribute on original buttons before cloning them.