### PR TITLE
fixes #218 glossary links removed at translation submission

### DIFF
--- a/js/glotdict-functions.js
+++ b/js/glotdict-functions.js
@@ -105,6 +105,19 @@ function gd_add_project_links() {
 }
 
 /**
+ * Add links to glossary words
+ *
+ * @param {object} glossary_word node
+ * @returns void
+ */
+function gd_add_glossary_links(glossary_word) {
+  var word = jQuery(glossary_word);
+  var line = word.parents().eq(7).attr('row');
+  jQuery('#preview-' + line).addClass('has-glotdict');
+  word.wrap('<a href="https://translate.wordpress.org/consistency?search=' + word.text() + '&amp;set=' + gd_get_lang_consistency() + '%2Fdefault" target="_blank" rel="noreferrer noopener"></a>');
+}
+
+/**
  * Add the review button
  * @returns void
  */
@@ -360,7 +373,7 @@ function gd_auto_hide_next_editor(editor) {
 /**
  * Mutations Observer for Translation Table Changes:
  * Auto hide next editor on status actions.
- * Add clone buttons on new preview rows.
+ * Add clone buttons on new preview rows and add glossary links.
  *
  * @triggers gd_add_column, gd_add_meta
  */
@@ -368,18 +381,19 @@ function gd_wait_table_alter() {
   if (document.querySelector('#translations tbody') !== null) {
     var observer = new MutationObserver(function(mutations) {
       mutations.forEach(function(mutation) {
-        if (document.querySelector('#bulk-actions-toolbar-top') === null) {
-          return;
-        }
+        var is_pte = document.querySelector('#bulk-actions-toolbar-top') !== null;
         mutation.addedNodes.forEach(function(addedNode) {
           if (addedNode.nodeType !== 1) {
             return;
           }
-          if (addedNode.classList.contains('editor') && mutation.previousSibling && !mutation.previousSibling.matches('.editor.untranslated')) {
+          if (is_pte && addedNode.classList.contains('editor') && mutation.previousSibling && !mutation.previousSibling.matches('.editor.untranslated')) {
             gd_auto_hide_next_editor(addedNode);
           }
-          if (addedNode.classList.contains('preview')) {
+          if (is_pte && addedNode.classList.contains('preview')) {
             gd_add_column_buttons(addedNode);
+          }
+          if (addedNode.classList.contains('preview')) {
+            addedNode.querySelectorAll('.glossary-word').forEach(gd_add_glossary_links);
           }
         });
         gd_add_meta();

--- a/js/glotdict.js
+++ b/js/glotdict.js
@@ -37,12 +37,7 @@ if (window.gd_filter_bar.length > 0) {
   jQuery("<div class='box has-old-string'></div><div>The translation is at least 6 months old</div>").appendTo('#legend');
   jQuery("<div class='box has-original-copy'></div><div>Contains the Original Copy</div>").appendTo('#legend');
 
-  jQuery('.glossary-word').each(function() {
-    var $this = jQuery(this);
-    var line = $this.parents().eq(7).attr('row');
-    jQuery('#preview-' + line).addClass('has-glotdict');
-    $this.wrap('<a href="https://translate.wordpress.org/consistency?search=' + $this.text() + '&amp;set=' + gd_get_lang_consistency() + '%2Fdefault" target="_blank" rel="noreferrer noopener"></a>');
-  });
+  document.querySelectorAll('.glossary-word').forEach(gd_add_glossary_links);
 
   gd_mark_old_strings();
 


### PR DESCRIPTION
Fixes  #218 moving the code for creating links in a function and using this function during the addedNode mutation