### PR TITLE
fixes #268 scroll button on stats that don't target the good locale

### DIFF
--- a/js/glotdict-functions.js
+++ b/js/glotdict-functions.js
@@ -163,11 +163,14 @@ function gd_add_scroll_buttons() {
   for (var regex in locations) {
     var position = document.querySelector('table');
     var acquired = (RegExp(locations[regex])).test(window.location.href);
+
     if (position && acquired) {
       jQuery(position).before('<button style="float:right;margin-bottom:1em" class="gd_scroll">Scroll to ' + gd_get_lang() + '</button>');
-
+      var StatsSpecificLinks = Array.prototype.slice.call(document.querySelectorAll('.stats-table tbody tr th a')).filter(function (el) {
+        return gd_get_lang() === el.textContent.trim()
+      })[0];
       jQuery('.gd_scroll').on('click', function() {
-        var target = document.querySelector('table tr th a[href*="/' + slug + '/"]') || document.querySelector('table td strong a[href*="/' + slug + '/"]');
+        var target = StatsSpecificLinks || document.querySelector('table tr th a[href*="/' + slug + '/"]') || document.querySelector('table td strong a[href*="/' + slug + '/"]');
         if (!target) { return; }
         var row = target.closest('tr');
         if (!row) { return; }


### PR DESCRIPTION
Global stats have specific links that couldn't been targeted with the slug in function gd_add_scroll_buttons.
So the solution is to get all the locales from the table tag in an array then filter it to find what gd_get_lang contains.
If there is a result it means that we are on the Stats page and we are using it, otherwise it is that we are on another page and we are using the following choices.