### PR TITLE
QuickLinks & Consistency Suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,4 @@ After that step we have to wait few hours for Chrome and for Firefox and all the
 * [Olegs Belousovs](https://github.com/sgelob) - The ideator
 * [Pascal Casier](https://github.com/ePascalC) - For the help with the glossaries and hotkeys
 * [Aurélien Joahny](https://github.com/ajoah) - For all the patches
+* [Vlad Timotei](https://github.com/vlad-timotei)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ PS: If you are using NoScript or Privacy Badger enable the domain wordpress.org 
 * Shortcut on Page Down to open the previous string to translate.
 * Shortcut on Page Up to open the next string to translate.
 * Right click of the mouse on the term with a dashed line and the translation will be added in the translation area.
-* Shortcut on Alt+C to start loading the consistency suggestions for a string.
+* Shortcut on Alt+C to start loading the consistency suggestions for current string.
 
 ## Settings
 * Don’t validate strings ending with “...“, “.”, “:”

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ PS: If you are using NoScript or Privacy Badger enable the domain wordpress.org 
 * Highlight non-breaking-space
 * Character and Word Counts in Meta
 * Notices with counts for Approved, Rejected, Fuzzied, Submitted and Selected rows
+* Consistency suggestions loaded directly in the editor
+* QuickLinks in Meta menu: open or copy link
 * Many hotkeys and shortcut
 
 ## Hotkeys
@@ -45,6 +47,7 @@ PS: If you are using NoScript or Privacy Badger enable the domain wordpress.org 
 * Shortcut on Page Down to open the previous string to translate.
 * Shortcut on Page Up to open the next string to translate.
 * Right click of the mouse on the term with a dashed line and the translation will be added in the translation area.
+* Shortcut on Alt+C to start loading the consistency suggestions for a string.
 
 ## Settings
 * Don’t validate strings ending with “...“, “.”, “:”

--- a/css/style.css
+++ b/css/style.css
@@ -168,6 +168,17 @@ button.gd-approve strong {
     content: "|";
     color: #c3c0c0;
 }
+.gd_get_consistency {
+	margin-left: 10px !important;
+}
+.translation-suggestion__translation.index,
+.consistency-count {
+	padding: 0 4px;
+	color: #666;
+}
+.consistency-count {
+	font-size: 0.8em;
+}
 @-webkit-keyframes gd-ripple-out {
 	0% {
 		box-shadow: 0 0 6px 6px rgba(0, 115, 170, .3);

--- a/css/style.css
+++ b/css/style.css
@@ -133,6 +133,41 @@ button.gd-approve strong {
 	-webkit-animation-name: gd-ripple-out;
     animation-name: gd-ripple-out;
 }
+.editor-panel__right .panel-header button {
+    background: none;
+    border: none;
+    height: 40px;
+    width: 40px;
+    padding: 0;
+    margin: 0;
+    vertical-align: middle;
+    box-shadow: none;
+    border-radius: 0;
+}
+.editor-panel__right .panel-header button:hover {
+    background: #fafafa;
+}
+.gd_quicklinks_copy.active {
+    color: #0073aa;
+}
+.gd_quicklinks_copy.active:hover,
+.gd_quicklinks_copy.active:focus {
+    color: #046594;
+}
+.gd_quicklinks_plus.dashicons-plus {
+	margin: 0 10px;
+    vertical-align: middle;
+    color: #0073aa;
+    cursor: pointer;
+}
+.gd_quicklinks_plus.separator {
+	margin: 0 10px;
+    vertical-align: middle;
+}
+.gd_quicklinks_plus.separator:before {
+    content: "|";
+    color: #c3c0c0;
+}
 @-webkit-keyframes gd-ripple-out {
 	0% {
 		box-shadow: 0 0 6px 6px rgba(0, 115, 170, .3);

--- a/js/glotdict-consistency.js
+++ b/js/glotdict-consistency.js
@@ -2,6 +2,7 @@ if ( typeof $gp !== 'undefined' ){
   var gd_quicklinks_copy_state = localStorage.getItem( 'gd_quicklinks_copy_state' ) === 'true';
   var gd_quicklinks_window = { 'closed': true };
   gd_quicklinks();
+  gd_consistency();
 }
 
 function gd_quicklinks(){
@@ -91,4 +92,69 @@ function gd_toggle_quicklinks_copy() {
   } );
   gd_quicklinks_copy_state = ! gd_quicklinks_copy_state;
   localStorage.setItem( 'gd_quicklinks_copy_state', gd_quicklinks_copy_state );
+}
+
+function gd_consistency(){
+  var gd_consistency_output = createElement( 'details', { 'class': 'gd_consistency suggestions__translation-consistency', 'open': 'open' } );
+  var gd_consistency_summary = createElement( 'summary', { }, 'Suggestions from Consistency' );
+  var gd_consistency_button = createElement( 'button', { 'class': 'gd_get_consistency' }, 'View Consistency suggestions' );
+  gd_consistency_output.append( gd_consistency_summary, gd_consistency_button );
+
+  addElements( '.editor-panel__left .suggestions-wrapper', 'beforeend', gd_consistency_output );
+  addEvtListener( 'click', '.gd_get_consistency', gd_show_consistency );
+}
+
+function gd_show_consistency( event ) {
+  event.target.textContent = 'Loading...';
+  var consistency_url = event.target.closest( '.editor-panel' ).querySelectorAll( '.button-menu__dropdown li a' )[ 2 ].href;
+
+  fetch( consistency_url )
+    .then( consistency_response => consistency_response.text() )
+    .then( consistency_response => {
+      var consistency_parser = new DOMParser();
+      var consistency_page = consistency_parser.parseFromString( consistency_response , 'text/html' );
+      var consistency_translations = consistency_page.querySelectorAll( '.consistency-table tbody th strong' );
+      var translations_count, unique_translation_count;
+
+      if ( consistency_translations.length == 1 ) {
+        unique_translation_count = consistency_page.querySelectorAll( 'tr' ).length - 2;
+        unique_translation_count = ' ('+ unique_translation_count + ' time' + ( ( unique_translation_count > 1 ) ? 's' : '' ) + ')';
+      } else {
+          translations_count = consistency_page.querySelectorAll( '.translations-unique small' );
+      }
+
+      var gd_consistency_suggestions;
+
+      if ( consistency_translations.length ) {
+        var gd_consistency_item,
+        gd_consistency_item_div,
+        gd_consistency_item_translation,
+        gd_consistency_item_index,
+        gd_consistency_item_count,
+        gd_consistency_item_raw,
+        gd_consistency_item_button;
+
+        gd_consistency_suggestions = createElement( 'ul', { class: 'suggestions-list' } );
+
+        for ( var i = 0; i < consistency_translations.length; i++ ) {
+          gd_consistency_item = document.createElement( 'li' );
+          gd_consistency_item_div = createElement( 'div', { 'class': 'translation-suggestion with-tooltip', 'role': 'button', 'aria-pressed': 'false', 'aria-label': 'Copy translation', 'tabindex': '0' } );
+          gd_consistency_item_translation = createElement( 'span', { 'class': 'translation-suggestion__translation' }, consistency_translations[ i ].textContent );
+          gd_consistency_item_index = createElement( 'span', { 'class': 'translation-suggestion__translation index' }, ( i + 1 ) + ': ' );
+          gd_consistency_item_count = createElement( 'span', { 'class': 'consistency-count' }, ( consistency_translations.length == 1 ) ? unique_translation_count : translations_count[ i ].textContent );
+          gd_consistency_item_raw = createElement( 'span', { 'class': 'translation-suggestion__translation-raw', 'aria-hidden': 'true' }, consistency_translations[ i ].textContent );
+          gd_consistency_item_button = createElement( 'button', { 'type': 'button', 'class': 'copy-suggestion' }, 'Copy' );
+          gd_consistency_item_translation.prepend( gd_consistency_item_index );
+          gd_consistency_item_translation.append( gd_consistency_item_count );
+          gd_consistency_item_div.append( gd_consistency_item_translation, gd_consistency_item_raw, gd_consistency_item_button );
+          gd_consistency_item.append( gd_consistency_item_div );
+          gd_consistency_suggestions.append( gd_consistency_item );
+        }
+      } else {
+          gd_consistency_suggestions = 'No suggestions.';
+      }
+      event.target.before ( gd_consistency_suggestions );
+      event.target.parentNode.removeChild( event.target );
+    } )
+    .catch( error => console.log( error ) );
 }

--- a/js/glotdict-consistency.js
+++ b/js/glotdict-consistency.js
@@ -1,0 +1,94 @@
+if ( typeof $gp !== 'undefined' ){
+  var gd_quicklinks_copy_state = localStorage.getItem( 'gd_quicklinks_copy_state' ) === 'true';
+  var gd_quicklinks_window = { 'closed': true };
+  gd_quicklinks();
+}
+
+function gd_quicklinks(){
+  var gd_quicklinks_output = createElement( 'span', { 'class': 'gd_quicklinks' } );
+  var gd_quicklinks_copy = createElement(
+    'button',
+    {
+      'type': 'button',
+      'class': 'gd_quicklinks_copy with-tooltip' + ( ( gd_quicklinks_copy_state ) ? ' active' : ' inactive' ),
+      'aria-label':'Click this and another to copy'
+    }
+  );
+  gd_quicklinks_copy.append(
+    createElement ( 'span', { 'class': 'screen-reader-text' }, 'Copy toggle' ),
+    createElement ( 'span', { 'class': 'dashicons dashicons-clipboard', 'aria-hidden': 'true' } )
+  );
+  var gd_quicklinks_separator = createElement(
+    'span',
+    {
+      'class': 'gd_quicklinks_plus dashicons' + ( ( gd_quicklinks_copy_state ) ? ' dashicons-plus' : ' separator' ),
+      'aria-hidden': 'true'
+    }
+  );
+  var gd_quicklinks_permalink = createElement( 'button', { 'class': 'gd_quicklinks_item gd_quicklinks_permalink with-tooltip', 'aria-label': 'Permalink to translation' } );
+  gd_quicklinks_permalink.append(
+    createElement ( 'span', { 'class': 'screen-reader-text' }, 'Permalink to translation' ),
+    createElement ( 'span', { 'class': 'dashicons dashicons-admin-links', 'aria-hidden': 'true' } )
+  );
+
+  var gd_quicklinks_history = createElement( 'button', { 'class': 'gd_quicklinks_item gd_quicklinks_history with-tooltip', 'aria-label': 'Translation History' } );
+  gd_quicklinks_history.append(
+    createElement ( 'span', { 'class': 'screen-reader-text' }, 'Translation History' ),
+    createElement ( 'span', { 'class': 'dashicons dashicons-backup', 'aria-hidden': 'true' } )
+  );
+
+  var gd_quicklinks_consistency = createElement( 'button', { 'class': 'gd_quicklinks_item gd_quicklinks_consistency with-tooltip', 'aria-label': 'View original in consistency tool' } );
+  gd_quicklinks_consistency.append(
+    createElement ( 'span', { 'class': 'screen-reader-text' }, 'View original in consistency tool' ),
+    createElement ( 'span', { 'class': 'dashicons dashicons-list-view', 'aria-hidden': 'true' } )
+  );
+
+  gd_quicklinks_output.append(
+    gd_quicklinks_copy,
+    gd_quicklinks_separator,
+    gd_quicklinks_permalink,
+    gd_quicklinks_history,
+    gd_quicklinks_consistency
+  );
+
+  addElements( '.editor-panel__right .panel-header', 'beforeend', gd_quicklinks_output );
+
+  document.querySelectorAll( '.editor' ).forEach( function( editor ){
+    var editor_menu = editor.querySelectorAll( '.button-menu__dropdown li a' );
+    editor.querySelector( '.gd_quicklinks_permalink' ).dataset.quicklink = editor_menu[ 0 ].href;
+    editor_menu[ 1 ].href += '&historypage';
+    editor.querySelector( '.gd_quicklinks_history' ).dataset.quicklink =  editor_menu[ 1 ].href;
+    editor.querySelector( '.gd_quicklinks_consistency' ).dataset.quicklink = editor_menu[ 2 ].href + '&consistencypage';
+  } );
+
+  addEvtListener( 'click', '.gd_quicklinks_copy, .gd_quicklinks_plus', gd_toggle_quicklinks_copy );
+  addEvtListener( 'click', '.gd_quicklinks_item', gd_do_quicklinks );
+}
+
+function gd_do_quicklinks( event ) {
+  if ( gd_quicklinks_copy_state ) {
+    var btn_target = event.currentTarget;
+    var current_aria_label = btn_target.getAttribute( 'aria-label' );
+    copyToClipboard( event.currentTarget.dataset.quicklink );
+    btn_target.setAttribute( 'aria-label', 'Copied!' );
+    setTimeout( function() { btn_target.setAttribute( 'aria-label', current_aria_label ); }, 2000 );
+  } else {
+      if ( ! gd_quicklinks_window.closed ) {
+        gd_quicklinks_window.close();
+      }
+    gd_quicklinks_window = window.open( event.currentTarget.dataset.quicklink, '_blank' );
+  }
+}
+
+function gd_toggle_quicklinks_copy() {
+  document.querySelectorAll( '.gd_quicklinks_plus' ).forEach( function( el ) {
+    el.classList.toggle( 'dashicons-plus' );
+    el.classList.toggle( 'separator' );
+  } );
+  document.querySelectorAll( '.gd_quicklinks_copy' ).forEach( function( el ) {
+    el.classList.toggle( 'active' );
+    el.classList.toggle( 'inactive' );
+  } );
+  gd_quicklinks_copy_state = ! gd_quicklinks_copy_state;
+  localStorage.setItem( 'gd_quicklinks_copy_state', gd_quicklinks_copy_state );
+}

--- a/js/glotdict-functions.js
+++ b/js/glotdict-functions.js
@@ -411,3 +411,65 @@ function gd_wait_table_alter() {
     });
   }
 }
+
+/**
+ * Creates HTML Element.
+ *
+ * @param {String} tagName This must be a valid HTML tag name.
+ * @param {Object} attributes
+ * @param {String} textContent
+ * @returns {Element}
+ */
+function createElement( tagName = 'div', attributes = {}, textContent = '' ) {
+  var element = document.createElement( tagName );
+  for ( var attribute in attributes ) {
+    if ( attributes.hasOwnProperty( attribute ) ) {
+      element.setAttribute( attribute, attributes[ attribute ] );
+    }
+  }
+  element.textContent = textContent;
+  return element;
+}
+
+/**
+ * Inserts adjacent elements to all target selectors.
+ *
+ * @param {String} target_selector This must be valid CSS syntax.
+ * @param {('beforebegin' | 'afterbegin' | 'beforeend' | 'afterend')} el_position
+ * @param {Element} new_element
+ * @returns {void}
+ */
+function addElements( target_selector, el_position, new_element ) {
+  document.querySelectorAll( target_selector ).forEach( function( el ){
+    el.insertAdjacentElement( el_position , new_element.cloneNode( true ) );
+  } );
+}
+
+/**
+ * Adds event listeners for all target selectors.
+ *
+ * @param {Event} event_name
+ * @param {String} target_selector This must be valid CSS syntax.
+ * @param {Function} function_to_call
+ * @returns {void}
+ */
+function addEvtListener( event_name, target_selector, function_to_call ) {
+  document.querySelectorAll( target_selector ).forEach( function( el ){
+    el.addEventListener( event_name, function_to_call );
+  } );
+}
+
+/**
+ * Copies text to clipboard.
+ *
+ * @param {String} copy_text
+ * @returns {void}
+ */
+function copyToClipboard( copy_text ) {
+  var elem = document.createElement( 'textarea' );
+  elem.value = copy_text;
+  document.body.appendChild( elem );
+  elem.select();
+  document.execCommand( 'copy' );
+  document.body.removeChild( elem );
+}

--- a/js/glotdict-hotkey.js
+++ b/js/glotdict-hotkey.js
@@ -117,8 +117,8 @@ function gd_hotkeys() {
     return false;
   });
   key('alt+c', function() {
-    if (jQuery('.editor:visible').length > 0) {
-      jQuery('.editor:visible .gd_get_consistency').trigger('click');
+    if ( jQuery( '.editor:visible' ).length > 0 ) {
+      jQuery( '.editor:visible .gd_get_consistency' ).trigger( 'click' );
     }
     return false;
   });

--- a/js/glotdict-hotkey.js
+++ b/js/glotdict-hotkey.js
@@ -116,4 +116,10 @@ function gd_hotkeys() {
     $gp.editor.next();
     return false;
   });
+  key('alt+c', function() {
+    if (jQuery('.editor:visible').length > 0) {
+      jQuery('.editor:visible .gd_get_consistency').trigger('click');
+    }
+    return false;
+  });
 }

--- a/js/glotdict-settings.js
+++ b/js/glotdict-settings.js
@@ -44,6 +44,7 @@ function gd_generate_settings_panel() {
     '<li>Shortcut on Page Down to open the previous string to translate.</li>' +
     '<li>Shortcut on Page Up to open the next string to translate.</li>' +
     '<li>Right click of the mouse on the term with a dashed line and the translation will be added in the translation area.</li>' +
+    '<li>Shortcut on Alt+C to start loading the consistency suggestions for current string.</li>' +
     '</ul><br><h3>Settings</h3>';
   jQuery('.gd_settings_panel').append(hotkeys);
   jQuery.each(settings, function(key, value) {

--- a/js/init.js
+++ b/js/init.js
@@ -1,4 +1,4 @@
-var jsScripts = ['jquery.bind-first', 'dompurify', 'keymaster', 'glotdict-locales', 'glotdict-functions', 'glotdict-settings', 'glotdict-hotkey', 'glotdict-validation', 'glotdict-column', 'glotdict-meta', 'glotdict-bulk', 'glotdict-notices', 'glotdict'];
+var jsScripts = ['jquery.bind-first', 'dompurify', 'keymaster', 'glotdict-locales', 'glotdict-functions', 'glotdict-settings', 'glotdict-hotkey', 'glotdict-validation', 'glotdict-column', 'glotdict-meta', 'glotdict-bulk', 'glotdict-notices', 'glotdict-consistency', 'glotdict'];
 
 script(jsScripts);
 

--- a/manifest.json
+++ b/manifest.json
@@ -22,6 +22,7 @@
     "js/glotdict-bulk.js",
     "js/glotdict-column.js",
     "js/glotdict-meta.js",
+    "js/glotdict-consistency.js",
     "js/glotdict-settings.js",
     "js/keymaster.js",
     "js/jquery.bind-first.js",


### PR DESCRIPTION
# QuickLinks

![QuickLinks_demo](https://user-images.githubusercontent.com/65488419/127768710-bd142fb5-bd7a-412e-8461-456e0eb702ba.gif)

 - Many times, we’d like to either open or copy one of the links in the Hamburger menu: Permalink, History or Consistency and we can do that, but I’d like an easier way to do that. This adds quick icon links to either copy or open in a new tab that link.
 - User clicks on any of those 3 right icons and a new tab is opened.
 - If a user clicks on the Clipboard icon, that gets blue and a + pops up, suggesting that now you can press on those three icons and the link will be copied to clipboard.
- The toggle between copy/open is stored as a preference and it is also updated for all menus in that page when the user does the toggle.


# Consistency Suggestions
![Consistency_demo](https://user-images.githubusercontent.com/65488419/127769117-d027dca5-7526-4c7a-ac73-c496dadc03fb.gif)
 - Translation Memory sometimes has bad translations (see #meta5340). This shows Consistency translations directly in the editor panel.
 - Loading a Consistency page takes a few seconds or more depending on the query, so without an API, it's not efficient load all consistency suggestions for all strings on a page when the page loads.
- User clicks a button or a keyboard shortcut (`Alt + C`) to start loading the consistency suggestions for a string.
- The suggestions load as any other suggestions in that area - they can be copied and also the state of the suggestion block (open/closed) is being stored, as part of GP core features.


## Testing
**QuickLinks**
- Open each link in new tab
- Copy each link
- Remember copy toggle status

**Consistency Suggestions**
- Loading suggestions
- Copy to editor
- Remember details state
- Alt + C keyboard shortcut

### Browser tested
- Microsoft Edge 92.0.902.62
- Google Chrome 92.0.4515.107
- Firefox 90.0.2 (could not test keyboard shortcut)
- Opera 77.0.4054.277
- Brave 1.27.109

