### PR TITLE
Fix string count #277

### DIFF
--- a/js/glotdict-meta.js
+++ b/js/glotdict-meta.js
@@ -28,7 +28,7 @@ function gd_add_string_counts(row) {
 
                     gd_add_count(row, jQuery(this).find('textarea.foreign-text'), 'current-count-'+index, 'Current String');
 
-                    jQuery(this).on("change keyup paste", 'textarea.foreign-text', function() {
+                    jQuery(this).on("change keyup paste focus", 'textarea.foreign-text', function() {
                         gd_update_count(row, jQuery(this), 'current-count-'+index, true);
                     });                    
                 });
@@ -43,7 +43,7 @@ function gd_add_string_counts(row) {
 
                     gd_add_count(row, jQuery(this).find('textarea.foreign-text'), 'current-count-'+index, prefix + 'Current');
 
-                    jQuery(this).on("change keyup paste", 'textarea.foreign-text', function() {
+                    jQuery(this).on("change keyup paste focus", 'textarea.foreign-text', function() {
                         gd_update_count(row, jQuery(this), 'current-count-'+index, true);
                     });                    
                 });
@@ -58,7 +58,7 @@ function gd_add_string_counts(row) {
 
             gd_add_count(row, jQuery('.textareas textarea.foreign-text', row), 'current-count', 'Current String');
 
-            jQuery(row).on("change keyup paste", '.textareas textarea.foreign-text', function() {
+            jQuery(row).on("change keyup paste focus", '.textareas textarea.foreign-text', function() {
                 gd_update_count(row, jQuery(this), 'current-count', true);
             });
         }


### PR DESCRIPTION
All Copy from suggestions events (Translation Memory, Another language and Copy from original) are done using .val():
[ref1](https://github.com/WordPress/wordpress.org/blob/e3619530994f1000f562c2f584cef9748ba73784/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/js/translation-suggestions.js#L86),  [ref2](https://github.com/GlotPress/GlotPress-WP/blob/0c395a7a8f37ab3b5ebafd2b239c74392e5177f9/assets/js/editor.js#L382)

According to [jQuery documentation](https://api.jquery.com/val/), "setting values using .val() method (or using the native value property) does not cause the dispatch of the change event. For this reason, the relevant event handlers will not be executed." 

This means that `on("change keyup paste)` is not enough to catch these events to fire gd_update_count(); However, in all cases, the .focus() event is also triggered. So we can indirectly listen to focus event. 

The patch adds `focus` in all 3 cases when it needs to listen for a change of the `textarea.foreign-text`

The above patch has been tested in Edge and Chrome.

Fixes #277