### PR TITLE
Fix shortcut descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ PS: If you are using NoScript or Privacy Badger enable the domain wordpress.org 
 * Shortcut on Ctrl+Shift+R to reset all the GlotDict settings.
 * Shortcut on Ctrl+D to dismiss the validation warnings for the currently visible editor.
 * Shortcut on Ctrl+Shift+D to dismiss all the validation warnings.
-* Shortcut on Page Down to open the previous string to translate.
-* Shortcut on Page Up to open the next string to translate.
+* Shortcut on Page Down to open the next string to translate.
+* Shortcut on Page Up to open the previous string to translate.
 * Right click of the mouse on the term with a dashed line and the translation will be added in the translation area.
 
 ## Settings

--- a/js/glotdict-settings.js
+++ b/js/glotdict-settings.js
@@ -41,8 +41,8 @@ function gd_generate_settings_panel() {
     '<li>Shortcut on Ctrl+Shift+R to reset all the GlotDict settings.</li>' +
     '<li>Shortcut on Ctrl+D to dismiss the validation warnings for the currently visible editor.</li>' +
     '<li>Shortcut on Ctrl+Shift+D to dismiss all the validation warnings.</li>' +
-    '<li>Shortcut on Page Down to open the previous string to translate.</li>' +
-    '<li>Shortcut on Page Up to open the next string to translate.</li>' +
+    '<li>Shortcut on Page Down to open the next string to translate.</li>' +
+    '<li>Shortcut on Page Up to open the previous string to translate.</li>' +
     '<li>Right click of the mouse on the term with a dashed line and the translation will be added in the translation area.</li>' +
     '</ul><br><h3>Settings</h3>';
   jQuery('.gd_settings_panel').append(hotkeys);


### PR DESCRIPTION
The descriptions for Page Up/Down are mixed up for some reason. 

https://github.com/Mte90/GlotDict/blob/875feb8a5801d5e63fb3f4d4e11f3757d7075d83/js/glotdict-hotkey.js#L111-L112
https://github.com/Mte90/GlotDict/blob/875feb8a5801d5e63fb3f4d4e11f3757d7075d83/js/glotdict-hotkey.js#L115-L116
