### PR TITLE
Improve Hotkeys documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,21 +33,23 @@ PS: If you are using NoScript or Privacy Badger enable the domain wordpress.org 
 
 ## Hotkeys
 
-* Shortcut on Ctrl+Enter to click "Suggest new translation" or "Add translation"
-* Shortcut on Ctrl+Shift+Enter to double click "Suggest new translation" or "Add translation" to force submission.
-* Shortcut on Ctrl+Shift+Z to click "Cancel".
-* Shortcut on Ctrl+Shift+A to click "Approve".
-* Shortcut on Ctrl+Shift+R to click "Reject".
-* Shortcut on Ctrl+Shift+F to click "Fuzzy".
-* Shortcut on Ctrl+Shift+B to "Copy from original".
-* Shortcut on Ctrl+Shift+X to add non-breaking spaces near symbols.
-* Shortcut on Ctrl+Shift+R to reset all the GlotDict settings.
-* Shortcut on Ctrl+D to dismiss the validation warnings for the currently visible editor.
-* Shortcut on Ctrl+Shift+D to dismiss all the validation warnings.
-* Shortcut on Page Down to open the next string to translate.
-* Shortcut on Page Up to open the previous string to translate.
-* Right click of the mouse on the term with a dashed line and the translation will be added in the translation area.
-* Shortcut on Alt+C to start loading the consistency suggestions for current string.
+| Hotkey | Action |
+| -- | -- |
+| Ctrl+Enter | Suggest or Save translation |
+| Ctrl+Shift+Enter | Force Suggest or Save translation |
+| Ctrl+Shift+A | Approve |
+| Ctrl+Shift+R | Reject |
+| Ctrl+Shift+F | Fuzzy |
+| Ctrl+Shift+Z | Cancel |
+| Ctrl+Shift+B | Copy from original |
+| Ctrl+Shift+X | Add non-breaking spaces near symbols |
+| Right click on a term | Add Glossary definition in the translation area |
+| Alt+C | Load consistency suggestions |
+| Ctrl+D | Dismiss validation warnings for the current visible editor |
+| Ctrl+Shift+D | Dismiss all validation warnings |
+| Ctrl+Shift+R | Reset all GlotDict settings |
+| Page Down | Open next string editor |
+| Page Up | Open previous string editor |
 
 ## Settings
 * Don’t validate strings ending with “...“, “.”, “:”

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ PS: If you are using NoScript or Privacy Badger enable the domain wordpress.org 
 | Hotkey | Action |
 | -- | -- |
 | Ctrl+Enter | Suggest or Save translation |
-| Ctrl+Shift+Enter | Force Suggest or Save translation |
+| Ctrl+Shift+Enter | Force suggest or Force save translation |
 | Ctrl+Shift+A | Approve |
 | Ctrl+Shift+R | Reject |
 | Ctrl+Shift+F | Fuzzy |

--- a/css/style.css
+++ b/css/style.css
@@ -182,6 +182,17 @@ button.gd-approve strong {
 .consistency-count {
 	font-size: 0.8em;
 }
+.gd-row {
+    border-bottom:1px solid #e8e8e8;
+}
+.gd-row div {
+    display: inline-block;
+    vertical-align: middle;
+    padding:5px;
+}
+.gd-row div:first-child {
+    width:25%;
+}
 @-webkit-keyframes gd-ripple-out {
 	0% {
 		box-shadow: 0 0 6px 6px rgba(0, 115, 170, .3);

--- a/js/glotdict-settings.js
+++ b/js/glotdict-settings.js
@@ -31,7 +31,7 @@ function gd_generate_settings_panel() {
   jQuery('.gp-content').prepend(container);
   var hotkeys = '<div class="gd-row"><div><h3>Hotkey</h3></div><div><h3>Action</h3></div></div>' +
   '<div class="gd-row"><div>Ctrl+Enter</div><div>Suggest or Save translation</div></div>' +
-  '<div class="gd-row"><div>Ctrl+Shift+Enter</div><div>Force Suggest or Save translation</div></div>' +
+  '<div class="gd-row"><div>Ctrl+Shift+Enter</div><div>Force suggest or Force save translation</div></div>' +
   '<div class="gd-row"><div>Ctrl+Shift+A</div><div>Approve</div></div>' +
   '<div class="gd-row"><div>Ctrl+Shift+R</div><div>Reject</div></div>' +
   '<div class="gd-row"><div>Ctrl+Shift+F</div><div>Fuzzy</div></div>' +

--- a/js/glotdict-settings.js
+++ b/js/glotdict-settings.js
@@ -29,23 +29,23 @@ function gd_generate_settings_panel() {
   };
   var container = '<div class="notice gd_settings_panel"><h2>GlotDict Settings</h2></div>';
   jQuery('.gp-content').prepend(container);
-  var hotkeys = '<h3>Hotkeys</h3><ul>' +
-    '<li>Shortcut on Ctrl+Enter to click "Suggest new translation" or "Add translation".</li>' +
-    '<li>Shortcut on Ctrl+Shift+Enter to double click "Suggest new translation" or "Add translation" to force submission.</li>' +
-    '<li>Shortcut on Ctrl+Shift+Z to click "Cancel".</li>' +
-    '<li>Shortcut on Ctrl+Shift+A to click "Approve".</li>' +
-    '<li>Shortcut on Ctrl+Shift+R to click "Reject".</li>' +
-    '<li>Shortcut on Ctrl+Shift+F to click "Fuzzy".</li>' +
-    '<li>Shortcut on Ctrl+Shift+B to "Copy from original".</li>' +
-    '<li>Shortcut on Ctrl+Shift+X to add non-breaking spaces near symbols.</li>' +
-    '<li>Shortcut on Ctrl+Shift+R to reset all the GlotDict settings.</li>' +
-    '<li>Shortcut on Ctrl+D to dismiss the validation warnings for the currently visible editor.</li>' +
-    '<li>Shortcut on Ctrl+Shift+D to dismiss all the validation warnings.</li>' +
-    '<li>Shortcut on Page Down to open the next string to translate.</li>' +
-    '<li>Shortcut on Page Up to open the previous string to translate.</li>' +
-    '<li>Right click of the mouse on the term with a dashed line and the translation will be added in the translation area.</li>' +
-    '<li>Shortcut on Alt+C to start loading the consistency suggestions for current string.</li>' +
-    '</ul><br><h3>Settings</h3>';
+  var hotkeys = '<div class="gd-row"><div><h3>Hotkey</h3></div><div><h3>Action</h3></div></div>' +
+  '<div class="gd-row"><div>Ctrl+Enter</div><div>Suggest or Save translation</div></div>' +
+  '<div class="gd-row"><div>Ctrl+Shift+Enter</div><div>Force Suggest or Save translation</div></div>' +
+  '<div class="gd-row"><div>Ctrl+Shift+A</div><div>Approve</div></div>' +
+  '<div class="gd-row"><div>Ctrl+Shift+R</div><div>Reject</div></div>' +
+  '<div class="gd-row"><div>Ctrl+Shift+F</div><div>Fuzzy</div></div>' +
+  '<div class="gd-row"><div>Ctrl+Shift+Z</div><div>Cancel</div></div>' +
+  '<div class="gd-row"><div>Ctrl+Shift+B</div><div>Copy from original</div></div>' +
+  '<div class="gd-row"><div>Ctrl+Shift+X</div><div>Add non-breaking spaces near symbols</div></div>' +
+  '<div class="gd-row"><div>Right click on a <span class="glossary-word">term</span></div><div>Add Glossary definition in the translation area</div></div>' +
+  '<div class="gd-row"><div>Alt+C</div><div>Load consistency suggestions</div></div>' +
+  '<div class="gd-row"><div>Ctrl+D</div><div>Dismiss validation warnings for the current visible editor</div></div>' +
+  '<div class="gd-row"><div>Ctrl+Shift+D</div><div>Dismiss all validation warnings</div></div>' +
+  '<div class="gd-row"><div>Ctrl+Shift+R</div><div>Reset all GlotDict settings</div></div>' +
+  '<div class="gd-row"><div>Page Down</div><div>Open next string editor</div></div>' +
+  '<div class="gd-row"><div>Page Up</div><div>Open previous string editor</div></div>' +
+  '<br><h3>Settings</h3>';
   jQuery('.gd_settings_panel').append(hotkeys);
   jQuery.each(settings, function(key, value) {
     var checked = '';


### PR DESCRIPTION
Hotkeys are a key point for GlotDict, so their documentation needs to be as accessible as possible. 
Hence, this PR suggests the transformation of Hotkeys list into a table for better readability. 

#### GlotDict Settings page:
Before:
![image](https://user-images.githubusercontent.com/65488419/130195445-bee2db9a-16e7-4ff1-aa88-e7c5fdb87130.png)

After:
![image](https://user-images.githubusercontent.com/65488419/130204168-b9b5507e-34e3-4c6b-aa1e-2b4291acd946.png)

#### GlotDict Readme:
Before:
![image](https://user-images.githubusercontent.com/65488419/130195855-490ff1b0-00c0-45ef-93af-9f8b0e20b527.png)

After:
![image](https://user-images.githubusercontent.com/65488419/130204454-b8bfb3ed-e33b-466e-bd22-6a806662b505.png)

### Feedback needed

- I would like some feedback on the Hotkeys Action descriptions and their order. 
- [optional] Also, I would personally prefer to have the Action column to the left and the HotKey column to the right, but it might be just a personal preference. My motivation would be that a user looks for the action to find the hotkey and not the other way around.

