### PR TITLE
Fix marking strings with glossary terms

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,6 +1,23 @@
-.has-glotdict td:first-child,.has-glotdict th:first-child,.box.has-glotdict{
-	border-left-width: 2px !important;
-	border-left-color: blue !important;
+.box.has-glotdict {
+    border-left-width: 2px !important;
+    border-left-color: blue !important;
+}
+table.translations tr.preview.has-glotdict th,
+table.translations tr.preview.has-glotdict .original {
+    position: relative;
+}
+table.translations tr.preview.has-glotdict .original::before {
+    content: "";
+    display: inline-block;
+    width: 2px;
+    height: 100%;
+    background: blue;
+    position: absolute;
+    margin-left: -.5em;
+    margin-top: -.5em;
+}
+table.translations tr.preview.has-glotdict th+.priority+.original::before {
+    margin-left: calc(-.5em - 31px);
 }
 .has-old-string td:last-child,.has-old-string th:last-child,.box.has-old-string{
 	border-right-width: 2px !important;


### PR DESCRIPTION
After [Meta changeset 11051](https://meta.trac.wordpress.org/changeset/11051) that removed the Priority column, the CSS for `.has-glotdict` needs to be updated.

This patch has been tested using a 
- GTE/PTE account
- contributor account
- no account

For reference, we've explored some other simpler solutions with less rules as well, but they failed in one of the above scenarios.

Fixes: #295 
Props: @webaxones 