### PR TITLE
Contextmenu action fix

### DIFF
--- a/js/glotdict.js
+++ b/js/glotdict.js
@@ -59,7 +59,9 @@ jQuery( '.glotdict_language' ).change( () => {
 
 jQuery( '.glossary-word' ).contextmenu( function( e ) {
 	const info = jQuery( this ).data( 'translations' );
-	jQuery( '.editor:visible textarea' ).val( jQuery( '.editor:visible textarea' ).val() + info[0].translation );
+	jQuery( '.editor:visible textarea:visible' )
+		.val( jQuery( '.editor:visible textarea:visible' ).val() + info[ 0 ].translation )
+		.focus();
 	e.preventDefault();
 	return false;
 } );


### PR DESCRIPTION
Fix contextmenu action for glossary word in relation to plurals and word count:

1. To prevent all textareas from the visible editor to be appended with the translation for the glossary term, make sure we select `textarea:visible`.

2. Since .`val()` doesn't cause the dispatch of the change event, we need to fire `.focus()` event. This will fire `gd_update_count` so we have accurate info in the Meta panel.

Fixes: #292