### PR TITLE
refactoring of the gd_generate_settings_panel function

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -244,20 +244,6 @@ button.gd-approve strong {
     font-size: 0.8em;
 }
 
-.gd-row {
-    border-bottom: 1px solid #e8e8e8;
-}
-
-.gd-row div {
-    display: inline-block;
-    vertical-align: middle;
-    padding: 5px;
-}
-
-.gd-row div:first-child {
-    width: 25%;
-}
-
 @-webkit-keyframes gd-ripple-out {
     0% {
         box-shadow: 0 0 6px 6px rgba(0, 115, 170, .3);

--- a/css/style.css
+++ b/css/style.css
@@ -306,6 +306,10 @@ button.gd-approve strong {
 
 .gd_settings_panel label {
     padding-left: 20px;
+    cursor: pointer;
+    width: -webkit-fit-content;
+    width: -moz-fit-content;
+    width: fit-content;
 }
 
 .gd_settings_questions {

--- a/css/style.css
+++ b/css/style.css
@@ -2,10 +2,12 @@
     border-left-width: 2px !important;
     border-left-color: blue !important;
 }
+
 table.translations tr.preview.has-glotdict th,
 table.translations tr.preview.has-glotdict .original {
     position: relative;
 }
+
 table.translations tr.preview.has-glotdict .original::before {
     content: "";
     display: inline-block;
@@ -16,121 +18,152 @@ table.translations tr.preview.has-glotdict .original::before {
     margin-left: -.5em;
     margin-top: -.5em;
 }
+
 table.translations tr.preview.has-glotdict th+.priority+.original::before {
     margin-left: calc(-.5em - 31px);
 }
-.has-old-string td:nth-last-child(2),.has-old-string th:nth-last-child(2),.box.has-old-string{
-	border-right-width: 2px !important;
-	border-right-color: black !important;
-}
-table.translations tr.preview.has-original-copy, #legend .has-original-copy {
-	background: #e5f5fa;
+
+.has-old-string td:nth-last-child(2),
+.has-old-string th:nth-last-child(2),
+.box.has-old-string {
+    border-right-width: 2px !important;
+    border-right-color: black !important;
 }
 
-.discard-glotdict{
-	float:right;
+table.translations tr.preview.has-original-copy,
+#legend .has-original-copy {
+    background: #e5f5fa;
 }
-.gd-layover{
-	height: 100%;
-	width: 100%;
-	background: #0009;
-	z-index: 99999;
-	position: absolute;
-	top: 0;
+
+.discard-glotdict {
+    float: right;
 }
+
+.gd-layover {
+    height: 100%;
+    width: 100%;
+    background: #0009;
+    z-index: 99999;
+    position: absolute;
+    top: 0;
+}
+
 .gd-loader,
 .gd-loader:after {
-	border-radius: 50%;
-	width: 10em;
-	height: 10em;
+    border-radius: 50%;
+    width: 10em;
+    height: 10em;
 }
+
 .gd-loader {
-	margin: 60px auto;
-	font-size: 10px;
-	position: relative;
-	width: 240px;
-	height: 240px;
-	text-indent: -9999em;
-	border-top: 1.1em solid rgba(255, 255, 255, 0.2);
-	border-right: 1.1em solid rgba(255, 255, 255, 0.2);
-	border-bottom: 1.1em solid rgba(255, 255, 255, 0.2);
-	border-left: 1.1em solid #ffffff;
-	transform: translateZ(0);
-	animation: load8 1.1s infinite linear;
+    margin: 60px auto;
+    font-size: 10px;
+    position: relative;
+    width: 240px;
+    height: 240px;
+    text-indent: -9999em;
+    border-top: 1.1em solid rgba(255, 255, 255, 0.2);
+    border-right: 1.1em solid rgba(255, 255, 255, 0.2);
+    border-bottom: 1.1em solid rgba(255, 255, 255, 0.2);
+    border-left: 1.1em solid #ffffff;
+    -webkit-transform: translateZ(0);
+    transform: translateZ(0);
+    -webkit-animation: load8 1.1s infinite linear;
+    animation: load8 1.1s infinite linear;
 }
+
 @-webkit-keyframes load8 {
-	0% {
-		transform: rotate(0deg);
-	}
-	100% {
-		transform: rotate(360deg);
-	}
+    0% {
+        -webkit-transform: rotate(0deg);
+        transform: rotate(0deg);
+    }
+
+    100% {
+        -webkit-transform: rotate(360deg);
+        transform: rotate(360deg);
+    }
 }
+
 @keyframes load8 {
-	0% {
-		-webkit-transform: rotate(0deg);
-		transform: rotate(0deg);
-	}
-	100% {
-		-webkit-transform: rotate(360deg);
-		transform: rotate(360deg);
-	}
+    0% {
+        -webkit-transform: rotate(0deg);
+        transform: rotate(0deg);
+    }
+
+    100% {
+        -webkit-transform: rotate(360deg);
+        transform: rotate(360deg);
+    }
 }
+
 .notice.approved {
-	background: #b5e1b9;
-	border-left: 3px solid #46b450;
+    background: #b5e1b9;
+    border-left: 3px solid #46b450;
 }
+
 .notice.rejected {
-	background: #f1adad;
-	border-left: 3px solid #dc3232;
+    background: #f1adad;
+    border-left: 3px solid #dc3232;
 }
+
 .notice.fuzzied {
-	background: #fbc5a9;
-	border-left: 3px solid #f56e28;
+    background: #fbc5a9;
+    border-left: 3px solid #f56e28;
 }
+
 .notice.submitted {
-	background: #b5e1b9;
-	border-left: 3px solid #46b450;
+    background: #b5e1b9;
+    border-left: 3px solid #46b450;
 }
+
 .notice.reviewed.warned {
-	color: #fff;
-	background: #e44b3e;
-	border-left: 3px solid #dc3232;
+    color: #fff;
+    background: #e44b3e;
+    border-left: 3px solid #dc3232;
 }
+
 button[class*="gd-"] strong {
-	display: inline-block;
+    display: inline-block;
 }
+
 .gd-btn-action {
-	-webkit-animation: gd-rotation 2s infinite linear;
-	        animation: gd-rotation 2s infinite linear;
+    -webkit-animation: gd-rotation 2s infinite linear;
+    animation: gd-rotation 2s infinite linear;
 }
+
 input.button.gd-review {
-	margin-top: 5px !important;
+    margin-top: 5px !important;
 }
+
 button.gd-approve strong {
-	-webkit-transform-origin: 51% 49%;
-	        transform-origin: 51% 49%;
+    -webkit-transform-origin: 51% 49%;
+    transform-origin: 51% 49%;
 }
+
 @-webkit-keyframes gd-rotation {
-	from {
-		-webkit-transform: rotate(0deg);
-		        transform: rotate(0deg);
-	}
-	to {
-		-webkit-transform: rotate(359deg);
-		        transform: rotate(359deg);
-	}
+    from {
+        -webkit-transform: rotate(0deg);
+        transform: rotate(0deg);
+    }
+
+    to {
+        -webkit-transform: rotate(359deg);
+        transform: rotate(359deg);
+    }
 }
+
 @keyframes gd-rotation {
-	from {
-		-webkit-transform: rotate(0deg);
-		        transform: rotate(0deg);
-	}
-	to {
-		-webkit-transform: rotate(359deg);
-		        transform: rotate(359deg);
-	}
+    from {
+        -webkit-transform: rotate(0deg);
+        transform: rotate(0deg);
+    }
+
+    to {
+        -webkit-transform: rotate(359deg);
+        transform: rotate(359deg);
+    }
 }
+
 .gd-locale-moved {
     display: inline-block;
     position: relative;
@@ -138,21 +171,23 @@ button.gd-approve strong {
     -webkit-transform: perspective(1px) translateZ(0);
     transform: perspective(1px) translateZ(0);
 }
+
 .gd-locale-moved:before {
-	z-index:-1;
+    z-index: -1;
     content: '';
     position: absolute;
     top: 0;
     right: 0;
     bottom: 0;
     left: 0;
-	-webkit-animation-duration: 1s;
+    -webkit-animation-duration: 1s;
     animation-duration: 1s;
-	-webkit-animation-delay: .5s;
+    -webkit-animation-delay: .5s;
     animation-delay: .5s;
-	-webkit-animation-name: gd-ripple-out;
+    -webkit-animation-name: gd-ripple-out;
     animation-name: gd-ripple-out;
 }
+
 .editor-panel__right .panel-header button {
     background: none;
     border: none;
@@ -164,73 +199,190 @@ button.gd-approve strong {
     box-shadow: none;
     border-radius: 0;
 }
+
 .editor-panel__right .panel-header button:hover {
     background: #fafafa;
 }
+
 .gd_quicklinks_copy.active {
     color: #0073aa;
 }
+
 .gd_quicklinks_copy.active:hover,
 .gd_quicklinks_copy.active:focus {
     color: #046594;
 }
+
 .gd_quicklinks_plus.dashicons-plus {
-	margin: 0 10px;
+    margin: 0 10px;
     vertical-align: middle;
     color: #0073aa;
     cursor: pointer;
 }
+
 .gd_quicklinks_plus.separator {
-	margin: 0 10px;
+    margin: 0 10px;
     vertical-align: middle;
 }
+
 .gd_quicklinks_plus.separator:before {
     content: "|";
     color: #c3c0c0;
 }
+
 .gd_get_consistency {
-	margin-left: 10px !important;
+    margin-left: 10px !important;
 }
+
 .translation-suggestion__translation.index,
 .consistency-count {
-	padding: 0 4px;
-	color: #666;
+    padding: 0 4px;
+    color: #666;
 }
+
 .consistency-count {
-	font-size: 0.8em;
+    font-size: 0.8em;
 }
+
 .gd-row {
-    border-bottom:1px solid #e8e8e8;
+    border-bottom: 1px solid #e8e8e8;
 }
+
 .gd-row div {
     display: inline-block;
     vertical-align: middle;
-    padding:5px;
+    padding: 5px;
 }
+
 .gd-row div:first-child {
-    width:25%;
+    width: 25%;
 }
+
 @-webkit-keyframes gd-ripple-out {
-	0% {
-		box-shadow: 0 0 6px 6px rgba(0, 115, 170, .3);
-	}
-	100% {
-		top: -22px;
-		right: -22px;
-		bottom: -22px;
-		left: -22px;
-		opacity: 0;
-	}
+    0% {
+        box-shadow: 0 0 6px 6px rgba(0, 115, 170, .3);
+    }
+
+    100% {
+        top: -22px;
+        right: -22px;
+        bottom: -22px;
+        left: -22px;
+        opacity: 0;
+    }
 }
+
 @keyframes gd-ripple-out {
-	0% {
-		box-shadow: 0 0 6px 6px rgba(0, 115, 170, .3);
-	}
-	100% {
-		top: -22px;
-		right: -22px;
-		bottom: -22px;
-		left: -22px;
-		opacity: 0;
-	}
+    0% {
+        box-shadow: 0 0 6px 6px rgba(0, 115, 170, .3);
+    }
+
+    100% {
+        top: -22px;
+        right: -22px;
+        bottom: -22px;
+        left: -22px;
+        opacity: 0;
+    }
+}
+
+.gd_settings_panel {
+    display: -ms-flexbox;
+    display: flex;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    -ms-flex-wrap: wrap;
+    flex-wrap: wrap;
+}
+
+.gd_settings_panel fieldset,
+.gd_settings_panel table {
+    margin-bottom: 10px;
+}
+
+.gd_settings_panel table {
+    width: 100%;
+    border-spacing: 1px;
+}
+
+.gd_settings_panel fieldset {
+    display: -ms-flexbox;
+    display: flex;
+    -ms-flex-direction: column;
+    flex-direction: column;
+}
+
+.gd_settings_panel label,
+.gd_settings_questions p {
+    padding: 3px 0;
+    margin: 0;
+}
+
+.gd_settings_panel label {
+    padding-left: 20px;
+}
+
+.gd_settings_questions {
+    text-align: center;
+}
+
+.gd_settings_panel th,
+.gd_settings_panel td {
+    padding: 3px 5px;
+}
+
+.gd_settings_panel th:first-child,
+.gd_settings_panel td:first-child {
+    padding-right: 10px;
+}
+
+.gd_settings_panel input[type="checkbox"] {
+    margin-right: 6px;
+    margin-left: -20px;
+    vertical-align: -1px;
+}
+
+.gd_settings_panel th,
+.gd_settings_questions p {
+    font-weight: bold;
+}
+
+.gd_settings_panel th {
+    background-color: #d7e8ef;
+    padding: 5px;
+}
+
+.gd_settings_panel td {
+    width: 50%;
+    background-color: #e1f0f5;
+}
+
+.gd_settings_panel tr:hover td {
+    background-color: #0073aa;
+    color: white;
+}
+
+@media screen and (min-width: 1920px) {
+    .gd_settings_panel {
+        -ms-flex-direction: row;
+        flex-direction: row;
+    }
+
+    .gd_settings_panel h2,
+    .gd_settings_questions {
+        width: 100%;
+    }
+
+    .gd_settings_questions {
+        margin-top: 10px;
+    }
+
+    .gd_settings_panel fieldset,
+    .gd_settings_panel table {
+        width: 50%;
+    }
+
+    .gd_settings_panel label {
+        max-width: 750px;
+    }
 }

--- a/js/glotdict-settings.js
+++ b/js/glotdict-settings.js
@@ -31,7 +31,7 @@ function gd_generate_settings_panel() {
 	};
 
 	const hotkeys = {
-		'Add Glossary definition in the translation area':            'Right click on a term',
+		'Add Glossary definition in the translation area':            'Right click on a Glossary term',
 		'Add non-breaking spaces near symbols':                       'Ctrl+Shift+X',
 		'Approve':                                                    'Ctrl+Shift+A',
 		'Cancel':                                                     'Ctrl+Shift+Z',

--- a/js/glotdict-settings.js
+++ b/js/glotdict-settings.js
@@ -5,15 +5,17 @@ jQuery( '.gd_setting' ).click( () => {
 	gd_generate_settings_panel();
 } );
 
-jQuery( '.gp-content' ).on( 'click', '.gd_settings_panel .gd_setting_check', function() {
+jQuery( '.gp-content' ).on( 'click', '.gd_settings_panel input[type="checkbox"]', function() {
 	localStorage.setItem( jQuery( this ).attr( 'id' ), jQuery( this ).is( ':checked' ) );
 } );
 
 function gd_generate_settings_panel() {
-	if ( 0 !== jQuery( '.gd_settings_panel' ).length ) {
-		jQuery( '.gd_settings_panel' ).toggle();
+	const gd_settings_panel = document.querySelector( '.gd_settings_panel' );
+	if ( null !== gd_settings_panel ) {
+		gd_settings_panel.style.display = ( 'none' === gd_settings_panel.style.display ) ? '' : 'none';
 		return;
 	}
+
 	const settings = {
 		'no_final_dot':                             'Don’t validate strings ending with “...“, “.”, “:”',
 		'no_final_other_dots':                      'Don’t validate strings ending with ;.!:、。؟？！',
@@ -27,36 +29,92 @@ function gd_generate_settings_panel() {
 		'autosubmit_bulk_copy_from_original':       'Auto-submit the "Copy From Original" Bulk Action (Warning: When enabled will submit all originals).',
 		'force_autosubmit_bulk_copy_from_original': 'Don’t validate strings during "Copy From Original" Bulk Action to bypass validation. (Warning: When enabled will submit originals with Glossary terms or other warnings.)',
 	};
-	const container = '<div class="notice gd_settings_panel"><h2>GlotDict Settings</h2></div>';
-	jQuery( '.gp-content' ).prepend( container );
-	const hotkeys = '<div class="gd-row"><div><h3>Hotkey</h3></div><div><h3>Action</h3></div></div>' +
-  '<div class="gd-row"><div>Ctrl+Enter</div><div>Suggest or Save translation</div></div>' +
-  '<div class="gd-row"><div>Ctrl+Shift+Enter</div><div>Force suggest or Force save translation</div></div>' +
-  '<div class="gd-row"><div>Ctrl+Shift+A</div><div>Approve</div></div>' +
-  '<div class="gd-row"><div>Ctrl+Shift+R</div><div>Reject</div></div>' +
-  '<div class="gd-row"><div>Ctrl+Shift+F</div><div>Fuzzy</div></div>' +
-  '<div class="gd-row"><div>Ctrl+Shift+Z</div><div>Cancel</div></div>' +
-  '<div class="gd-row"><div>Ctrl+Shift+B</div><div>Copy from original</div></div>' +
-  '<div class="gd-row"><div>Ctrl+Shift+X</div><div>Add non-breaking spaces near symbols</div></div>' +
-  '<div class="gd-row"><div>Right click on a <span class="glossary-word">term</span></div><div>Add Glossary definition in the translation area</div></div>' +
-  '<div class="gd-row"><div>Alt+C</div><div>Load consistency suggestions</div></div>' +
-  '<div class="gd-row"><div>Ctrl+D</div><div>Dismiss validation warnings for the current visible editor</div></div>' +
-  '<div class="gd-row"><div>Ctrl+Shift+D</div><div>Dismiss all validation warnings</div></div>' +
-  '<div class="gd-row"><div>Ctrl+Shift+R</div><div>Reset all GlotDict settings</div></div>' +
-  '<div class="gd-row"><div>Page Down</div><div>Open next string editor</div></div>' +
-  '<div class="gd-row"><div>Page Up</div><div>Open previous string editor</div></div>' +
-  '<br><h3>Settings</h3>';
-	jQuery( '.gd_settings_panel' ).append( hotkeys );
-	jQuery.each( settings, ( key, value ) => {
-		let checked = '';
-		if ( 'true' === localStorage.getItem( `gd_${key}` ) ) {
-			checked = 'checked';
-		}
-		jQuery( '.gd_settings_panel' ).append( `<input class="gd_setting_check" type="checkbox" id="gd_${key}" ${checked}> <label for="gd_${key}">${value}</label><br>` );
+
+	const hotkeys = {
+		'Add Glossary definition in the translation area':            'Right click on a term',
+		'Add non-breaking spaces near symbols':                       'Ctrl+Shift+X',
+		'Approve':                                                    'Ctrl+Shift+A',
+		'Cancel':                                                     'Ctrl+Shift+Z',
+		'Copy from original':                                         'Ctrl+Shift+B',
+		'Dismiss validation warnings for the current visible editor': 'Ctrl+D',
+		'Dismiss all validation warnings':                            'Ctrl+Shift+D',
+		'Force suggest or Force save translation':                    'Ctrl+Shift+Enter',
+		'Fuzzy':                                                      'Ctrl+Shift+F',
+		'Load consistency suggestions':                               'Alt+C',
+		'Open next string editor':                                    'Page Down',
+		'Open previous string editor':                                'Page Up',
+		'Reject':                                                     'Ctrl+Shift+R',
+		'Suggest or Save translation':                                'Ctrl+Enter',
+	}
+
+	const container = document.createElement( 'DIV' );
+	container.classList.add( 'notice', 'gd_settings_panel' );
+	container.appendChild( document.createElement( 'H2' ) ).appendChild( document.createTextNode( 'GlotDict Settings' ) );
+
+	const fragment = document.createDocumentFragment();
+	Object.entries( settings ).forEach( setting => {
+		const [ key, value ] = setting;
+		const input = document.createElement( 'INPUT' );
+		const label = document.createElement( 'LABEL' );
+		input.type = 'checkbox';
+		input.id = `gd_${key}`;
+		input.checked = ( 'true' === localStorage.getItem( `gd_${key}` ) ) ? 'checked' : '';
+		label.appendChild( input );
+		label.appendChild( document.createTextNode( `${value}` ) );
+		fragment.appendChild( label );
 	} );
-	jQuery( '.gd_settings_panel' ).append( '<br><h3>Are you looking for spell checking? Try <a href="https://www.grammarly.com/" target="_blank" rel="noreferrer noopener">Grammarly</a> or <a href="https://languagetool.org/" target="_blank" rel="noreferrer noopener">LanguageTool</a>.</h3>' );
-	jQuery( '.gd_settings_panel' ).append( '<h3>Do you want a new feature or settings? Ask <a href="https://github.com/Mte90/GlotDict/issues" target="_blank" rel="noreferrer noopener">here</a>.</h3>' );
-	jQuery( '.gd_settings_panel' ).append( '<h3>Do you like this browser extension? You can donate <a href="https://www.paypal.me/mte90" target="_blank" rel="noreferrer noopener">here</a>.</h3>' );
+	const fieldset = document.createElement( 'FIELDSET' );
+	fieldset.appendChild( fragment );
+	container.appendChild( fieldset );
+
+	fragment.appendChild( document.createElement( 'TH' ) ).appendChild( document.createTextNode( 'Action' ) );
+	fragment.appendChild( document.createElement( 'TH' ) ).appendChild( document.createTextNode( 'Hotkey' ) );
+	Object.entries( hotkeys ).forEach( hotkey => {
+		const [ key, value ] = hotkey;
+		const tr = document.createElement( 'TR' );
+		tr.appendChild( document.createElement( 'TD' ) ).appendChild( document.createTextNode( `${key}` ) );
+		tr.appendChild( document.createElement( 'TD' ) ).appendChild( document.createTextNode( `${value}` ) );
+		fragment.appendChild( tr );
+	} );
+	const table = document.createElement( 'TABLE' );
+	table.appendChild( fragment );
+	container.appendChild( table );
+
+	const grammarly = document.createElement( 'A' );
+	grammarly.target = '_blank';
+	grammarly.rel = 'noreferrer noopener';
+	const languagetool = grammarly.cloneNode( true );
+	const issues = grammarly.cloneNode( true );
+	const donate = grammarly.cloneNode( true );
+	grammarly.href = 'https://www.grammarly.com/';
+	grammarly.textContent = 'Grammarly';
+	languagetool.href = 'https://languagetool.org/';
+	languagetool.textContent = 'LanguageTool.';
+	issues.href = 'https://github.com/Mte90/GlotDict/issues';
+	issues.textContent = 'Ask here.';
+	donate.href = 'https://www.paypal.me/mte90';
+	donate.textContent = 'donate here.';
+
+	const question1 = document.createElement( 'P' );
+	const question2 = question1.cloneNode( true );
+	const question3 = question1.cloneNode( true );
+	question1.appendChild( document.createTextNode( 'Are you looking for spell checking? Try ' ) );
+	question1.appendChild( grammarly );
+	question1.appendChild( document.createTextNode( ' or ' ) );
+	question1.appendChild( languagetool );
+	fragment.appendChild( question1 );
+	question2.appendChild( document.createTextNode( 'Do you want a new feature or settings? ' ) );
+	question2.appendChild( issues );
+	fragment.appendChild( question2 );
+	question3.appendChild( document.createTextNode( 'Do you like this browser extension? You can ' ) );
+	question3.appendChild( donate );
+	fragment.appendChild( question3 );
+
+	const questions = document.createElement( 'DIV' );
+	questions.classList.add( 'gd_settings_questions' );
+	container.appendChild( questions ).appendChild( fragment );
+
+	document.querySelector( '.gp-content' ).prepend( container );
 }
 
 function gd_get_setting( key ) {


### PR DESCRIPTION
Refactoring of the gd_generate_settings_panel function for:

- use an object for hotkeys as well as for settings and thus make the data easier to modify
- append HTML safely and faster by:
  - removing the use of jQuery which is not optimized for modifying the DOM (It was not possible easily 4 years ago but it is now perfectly)
  - removing the use of all what is based on innerHTML which causes lots of refresh and is slower since it is based on htmlStrings that must be parsed
  - favoring native JS
  - favoring properties vs setAttribute except for non-standard attributes (faster)
  - using DocumentFragment when it's possible since elements added to the DocumentFragment don't affect the DOM until it is appended to the DOM
  
Some of the HTML tags have been replaced to be more W3C compliant: 

- real TABLE tag instead of false
- CSS styles instead of BR tags
- CSS styles instead of Hn for style

Some styles have been added for:

- make the settings more readable even if the style imposed by the theme of the site is anything but effective
- offer a specific display for large screens

1 hotkey line has been removed (not the shortcut itself which will need another PR since it may be a solution to keep a hidden shortcut for us, with other keys of course): Reset all GlotDict settings.

PR successfully tested on Chrome and Firefox

![settings](https://user-images.githubusercontent.com/17084006/131181672-d7d5c512-e79d-4e54-9e3c-20226d348fab.gif)

