### PR TITLE
fix URL check in gd_current_locale_first

### DIFF
--- a/js/glotdict-functions.js
+++ b/js/glotdict-functions.js
@@ -339,7 +339,7 @@ function gd_remove_layover() {
  * @returns {void}
  */
 function gd_current_locale_first() {
-	if ( ! ( /https:\/\/translate\.wordpress\.org\// ).test( window.location.href ) ) { return; }
+	if ( 'https://translate.wordpress.org/' !== document.URL ) { return; }
 	const locales_filter = document.querySelector( '#locales-filter' );
 	const slug = gd_get_locale_slug( gd_get_lang(), 'locale' );
 	const current_locale = document.querySelector( `#locales .english a[href="/locale/${slug}/"]` );


### PR DESCRIPTION
First check of the function which return if we are not on translate root didn't work since the regex was always true.
There was a second test 5 lines later which worked but you might as well get out as soon as possible if you are not on the right page.