### PR TITLE
fixes #302 by adding 2 CSS classes to body depending on GlotPress globals

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -352,6 +352,10 @@ button.gd-approve strong {
     color: white;
 }
 
+.gd-on-translations .gp-content {
+    max-width: 85%;
+}
+
 @media screen and (min-width: 1920px) {
     .gd_settings_panel {
         -ms-flex-direction: row;

--- a/js/glotdict.js
+++ b/js/glotdict.js
@@ -2,6 +2,9 @@
 
 const glotdict_version = '1.0.1';
 
+( 'undefined' !== typeof $gp ) && document.body.classList.add( 'gd-on-translations' );
+( 'undefined' !== typeof $gp_editor_options ) && '1' === $gp_editor_options.can_approve && document.body.classList.add( 'gd-user-is-editor' );
+
 gd_add_layover();
 
 gd_current_locale_first();
@@ -97,7 +100,3 @@ gd_curly_apostrophe_highlight();
 gd_wait_table_alter();
 
 gd_remove_layover();
-
-if ( jQuery( '.gp-content #upper-filters-toolbar' ).length > 0 ) {
-	jQuery( '.gp-content' ).css( 'max-width', '85%' );
-}

--- a/js/glotdict.js
+++ b/js/glotdict.js
@@ -2,8 +2,8 @@
 
 const glotdict_version = '1.0.1';
 
-( 'undefined' !== typeof $gp ) && document.body.classList.add( 'gd-on-translations' );
-( 'undefined' !== typeof $gp_editor_options ) && '1' === $gp_editor_options.can_approve && document.body.classList.add( 'gd-user-is-editor' );
+( 'undefined' !== typeof $gp_editor_options ) && '' === $gp_editor_options.can_approve && document.body.classList.add( 'gd-user-is-translator', 'gd-on-translations' );
+( 'undefined' !== typeof $gp_editor_options ) && '1' === $gp_editor_options.can_approve && document.body.classList.add( 'gd-user-is-editor', 'gd-on-translations' );
 
 gd_add_layover();
 


### PR DESCRIPTION
fixes #302
Add 2 CSS classes ("gd-on-translations" and "gd-user-is-editor"  depending on GlotPress globals: $gp and $gp_editor_options, and replace JS code with CSS for fullscreen table.
