### PR TITLE
Replace check of $gp variable with a more consistent one

### DIFF
--- a/js/glotdict-consistency.js
+++ b/js/glotdict-consistency.js
@@ -1,7 +1,7 @@
 let gd_quicklinks_copy_state = 'true' === localStorage.getItem( 'gd_quicklinks_copy_state' );
 let gd_quicklinks_window = { 'closed': true };
 
-if ( 'undefined' !== typeof $gp ) {
+if ( 'undefined' !== typeof $gp_editor_options ) {
 	gd_quicklinks();
 	gd_consistency();
 }


### PR DESCRIPTION
`$gp` is inconsistent for our usage to check if an editor is or not present.

This [cross-site analysis on global variables](https://docs.google.com/document/d/1S2smv7Oq6H_Qox4PDAop0A7qDodq2qsmN2qVbi1Npuo/edit#bookmark=id.5x1vwc1ppxjl) usage shows that `$gp_editor_options` is consistent with our need, being defined, only when an actual editor is present.

This replaces check of `$gp` with check of `$gp_editor_options`.
Tested on all the links in the list above.

See: #302 
Fixes: #304 