### PR TITLE
Hotkey update

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,22 +32,22 @@ PS: If you are using NoScript or Privacy Badger enable wordpress.org domain or e
 
 ## Hotkeys
 
-| Hotkey | Action |
+| Action | Hotkey |
 | -- | -- |
-| Ctrl+Enter | Suggest or Save translation |
-| Ctrl+Shift+Enter | Force suggest or Force save translation |
-| Ctrl+Shift+A | Approve |
-| Ctrl+Shift+R | Reject |
-| Ctrl+Shift+F | Fuzzy |
-| Ctrl+Shift+Z | Cancel |
-| Ctrl+Shift+B | Copy from original |
-| Ctrl+Shift+X | Add non-breaking spaces near symbols |
-| Right click on a term | Add Glossary definition in the translation area |
-| Alt+C | Load consistency suggestions |
-| Ctrl+D | Dismiss validation warnings for the current visible editor |
-| Ctrl+Shift+D | Dismiss all validation warnings |
-| Page Down | Open next string editor |
-| Page Up | Open previous string editor |
+| Add Glossary definition in the translation area | Right click on a Glossary term |
+| Add non-breaking spaces near symbols | Ctrl+Shift+X |
+| Approve | Ctrl+Shift+A |
+| Cancel | Ctrl+Shift+Z |
+| Copy from original | Ctrl+Shift+B |
+| Dismiss validation warnings for the current visible editor | Ctrl+D |
+| Dismiss all validation warnings | Ctrl+Shift+D |
+| Force suggest or Force save translation | Ctrl+Shift+Enter |
+| Fuzzy | Ctrl+Shift+F |
+| Load consistency suggestions | Alt+C |
+| Open next string editor | Page Down |
+| Open previous string editor | Page Up |
+| Reject | Ctrl+Shift+R |
+| Suggest or Save translation | Ctrl+Enter |
 
 ## Settings
 * Don’t validate strings ending with `...`, `.`, `:`

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ PS: If you are using NoScript or Privacy Badger enable wordpress.org domain or e
 | Alt+C | Load consistency suggestions |
 | Ctrl+D | Dismiss validation warnings for the current visible editor |
 | Ctrl+Shift+D | Dismiss all validation warnings |
-| Ctrl+Shift+R | Reset all GlotDict settings |
 | Page Down | Open next string editor |
 | Page Up | Open previous string editor |
 

--- a/js/glotdict-hotkey.js
+++ b/js/glotdict-hotkey.js
@@ -91,13 +91,6 @@ function gd_hotkeys() {
 		} );
 		return false;
 	} );
-	key( 'ctrl+shift+r', () => {
-		localStorage.removeItem( 'gd_language' );
-		localStorage.removeItem( 'gd_locales' );
-		localStorage.removeItem( 'gd_locales_date' );
-		location.reload();
-		return false;
-	} );
 	key( 'ctrl+d', () => {
 		jQuery( '.editor:visible .discard-glotdict' ).trigger( 'click' );
 		jQuery( '.editor:visible .discard-warning' ).trigger( 'click' );


### PR DESCRIPTION
1. The shortcut for resetting all settings is no longer needed, hence this removes it.
2. This aligns with #299 to use the same:
- hotkeys order
- column order: Action | Hotkey

Fixes: #291 