### PR TITLE
Improve settings text

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -352,6 +352,22 @@ button.gd-approve strong {
     color: white;
 }
 
+code {
+    padding: .2em .4em;
+    margin: 0 2px;
+    font-size: 85%;
+    background-color: #e4e4e4;
+    border-radius: 5px;
+}
+
+.gd_asterisk {
+    color: red;
+}
+
+.gd_settings_panel fieldset h3 {
+    padding: 15px 0 0 0;
+}
+
 .gd-on-translations .gp-content {
     max-width: 85%;
 }

--- a/js/glotdict-settings.js
+++ b/js/glotdict-settings.js
@@ -121,6 +121,13 @@ function gd_generate_settings_panel() {
 	table.appendChild( fragment );
 	container.appendChild( table );
 
+	const caution_note = document.createElement( 'SPAN' );
+	const asterisk = caution_note.cloneNode( true );
+	asterisk.textContent = '*';
+	asterisk.className = 'gd_asterisk';
+	caution_note.append( asterisk, 'Please use features marked like this with caution!' );
+	fragment.appendChild( caution_note );
+
 	const grammarly = document.createElement( 'A' );
 	grammarly.target = '_blank';
 	grammarly.rel = 'noreferrer noopener';
@@ -150,12 +157,6 @@ function gd_generate_settings_panel() {
 	question3.appendChild( document.createTextNode( 'Do you want a new feature or settings? ' ) );
 	question3.appendChild( issues );
 	fragment.appendChild( question3 );
-	const caution_note = document.createElement( 'SPAN' );
-	const asterisk = caution_note.cloneNode( true );
-	asterisk.textContent = '*';
-	asterisk.className = 'gd_asterisk';
-	caution_note.append( asterisk, 'Use with caution!' );
-	fragment.appendChild( caution_note );
 
 	const questions = document.createElement( 'DIV' );
 	questions.classList.add( 'gd_settings_questions' );


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/65488419/132543896-7b16e05b-ff1b-4b23-9bbb-5090fb308115.png)


-  Settings descriptions more easy to understand
- Uses `[[[ code ]]]` markdown for `<code>` in settings description.
- Adds `*` at the end of the setting description if needed, for dangerous settings.
- Adds "Use with caution" bottom notice.
- Reorders bottom questions to be sorted by length

This PR has been tested against [these tests](https://docs.google.com/document/d/1S2smv7Oq6H_Qox4PDAop0A7qDodq2qsmN2qVbi1Npuo/view) with the same result as 1.7.0, but additional tests are welcome.

Props: @webaxones
Fixes: #315 