### PR TITLE
Consistent language picker location

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -100,6 +100,28 @@ table.translations tr.preview.has-original-copy,
     }
 }
 
+.gd-language-picker-container {
+    display: inline-block;
+}
+
+.gd-language-picker-container.empty-locale {
+    padding: 2px 5px;
+    color: red;
+    font-weight: 600;
+}
+
+.gd-language-picker-container.empty-locale label:after {
+    content: ' glossary\2002 \2192  \2002';
+}
+
+.gd-language-picker-container.empty-locale #gd-language-picker {
+    border: 2px solid red;
+}
+
+.gd-language-picker-container label:after {
+    content: ': ';
+}
+
 .notice.approved {
     background: #b5e1b9;
     border-left: 3px solid #46b450;

--- a/js/glotdict-functions.js
+++ b/js/glotdict-functions.js
@@ -199,7 +199,7 @@ function gd_add_scroll_buttons() {
  */
 function gd_locales_selector() {
 	const lang = gd_get_lang();
-	window.gd_filter_bar.append( '<span class="separator">•</span><label for="gd-language-picker">Pick locale: </label><select id="gd-language-picker" class="glotdict_language"></select>' );
+	window.gd_filter_bar.append( `<span class="separator">•</span><div class="gd-language-picker-container${( '' === lang || false === lang ) ? ' empty-locale' : ''}"><label for="gd-language-picker">Pick locale</label><select id="gd-language-picker" class="glotdict_language"></select></div>` );
 	jQuery( '.glotdict_language' ).append( jQuery( '<option></option>' ) );
 	const gd_locales_array = gd_locales();
 	jQuery.each( gd_locales_array, ( key, value ) => {
@@ -209,10 +209,6 @@ function gd_locales_selector() {
 		}
 		jQuery( '.glotdict_language' ).append( new_option );
 	} );
-	if ( '' === lang || false === lang ) {
-		window.gd_filter_bar.append( '<h3 style="background-color:#ddd;padding:4px;width:130px;display:inline;margin-left:4px;color:red;">&larr; Set the glossary!</h3>' )
-			.append( '<br><h2 style="background-color:#fff;padding:0;display:block;text-align:center;margin-top: 6px;">Welcome to GlotDict! Discover the features and the hotkeys on the <a href="https://github.com/Mte90/GlotDict/blob/master/README.md#features"  target="_blank" rel="noreferrer noopener">Readme</a>.</h2>' );
-	}
 }
 
 /**

--- a/js/glotdict.js
+++ b/js/glotdict.js
@@ -45,10 +45,6 @@ gd_current_locale_first();
 
 window.gd_filter_bar = jQuery( '.filter-toolbar form div:first' );
 
-if ( jQuery( '.filters-toolbar.bulk-actions:last div:first' ).length > 0 ) {
-	window.gd_filter_bar = jQuery( '.filters-toolbar.bulk-actions:last div:first' );
-}
-
 if ( window.gd_filter_bar.length > 0 ) {
 	gd_hotkeys();
 	// Fix for PTE align


### PR DESCRIPTION
Currently, if user is PTE/GTE, the language picker is in the bottom part of the page.
This puts the language picker in the top part of the page for all users.

Also removes the Welcome to GD part - not needed anymore - it's included in What's new view.

Also adds new styles to the selector.

**PTE/GTE before and after choosing a locale**
![image](https://user-images.githubusercontent.com/65488419/133046938-fceb4b72-5bc4-49c4-8809-24c77f29bdba.png)
![image](https://user-images.githubusercontent.com/65488419/133047044-67a53557-dc5f-47f2-a91d-5c5345b718cf.png)

**Contributor before and after choosing a locale**
![image](https://user-images.githubusercontent.com/65488419/133047629-f596df71-627d-4d15-b8d0-331af5b651a4.png)
![image](https://user-images.githubusercontent.com/65488419/133047557-3575fc7d-3056-4530-84c5-004223448d91.png)


I removed this code that took into consideration the bottom filters toolbar. It is not used in other places, so other things are not affected. 

```js
if ( jQuery( '.filters-toolbar.bulk-actions:last div:first' ).length > 0 ) {
	window.gd_filter_bar = jQuery( '.filters-toolbar.bulk-actions:last div:first' );
}
```

Fixes: #287 