### PR TITLE
Fix gp-js-message z-index

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -591,6 +591,10 @@ button.gd-approve strong {
     z-index: 999999;
 }
 
+#gp-js-message {
+    z-index: 1000000;
+}
+
 #gd-notices-container {
     margin-top: 15px;
 }


### PR DESCRIPTION
This brings up the warning popup.
After the patch
![gd_hidden_warning_fix](https://user-images.githubusercontent.com/65488419/133238592-d83682ae-896a-4c10-ad79-a858df6a6a3b.gif)

Fixes: #322 