### PR TITLE
Check if is on translations before copy original

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,6 +21,7 @@
 		"gd_add_review_button": true,
 		"gd_add_scroll_buttons": true,
 		"gd_build_sticky_header": true,
+		"gd_copy_visible_original_string": true,
 		"gd_copy_to_clipboard": true,
 		"gd_create_element": true,
 		"gd_curly_apostrophe_highlight": true,

--- a/js/glotdict.js
+++ b/js/glotdict.js
@@ -114,7 +114,7 @@ jQuery( '.gp-content' ).on( 'click', '.discard-glotdict', function( e ) {
 	return false;
 } );
 
-if ( gd_get_setting( 'autocopy_string_on_translation_opened' ) ) {
+if ( gd_user.is_on_translations && gd_get_setting( 'autocopy_string_on_translation_opened' ) ) {
 	jQuery( $gp.editor.table ).on( 'click', 'a.edit', function() {
 		setTimeout(() => { gd_copy_visible_original_string(); }, 400);
 	} );


### PR DESCRIPTION
On a various set of pages (Homepage, Stats, Consitency, Locale main, Locale project, Locale subproject, Locale Stats, Project Overview) where `$gp` is not defined, not checking this results in an error, if `Auto-copy original to clipboard on editor opening` is enabled: `Uncaught ReferenceError: $gp is not defined`.

Also added `gd_copy_visible_original_string` to the list of esling globals.