### PR TITLE
Improve the readability of h2 on translation pages

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -620,6 +620,7 @@ button.gd-approve strong {
 #gd-toggle-header {
     float: right;
     margin-left: 40px;
+    margin-top: -1px;
 }
 
 .gd-toggle__input {
@@ -677,12 +678,60 @@ code {
     border-radius: 5px;
 }
 
+.gd-on-translations h2 {
+    font-size: 19px;
+    font-weight: 500;
+    line-height: 20px;
+}
+
+.gd-on-translations .gp-content h2 a.glossary-link {
+    font-size: 16px;
+    font-weight: 500;
+}
+
+.gd-on-translations .gp-content h2 a.glossary-link:last-child,
+.gd-on-translations .gp-content h2 a.glossary-link+a.glossary-link {
+    margin-right: 26px;
+}
+
+.gd-on-translations .gp-content h2 a.glossary-link:last-child::after,
+.gd-on-translations .gp-content h2 a.glossary-link+a.glossary-link::after {
+    position: absolute;
+    content: '';
+    display: inline-block;
+    height: 36px;
+    width: 1px;
+    background: #c4c4c4;
+    margin-left: 13px;
+    margin-top: -7px;
+}
+
 @media screen and (min-width: 1920px) {
+
+    .gd-on-translations h2 {
+        font-size: 20px;
+        line-height: 21px;
+    }
+
+    .gd-on-translations .gp-content h2 a.glossary-link {
+        font-size: 17px;
+    }
 
     #gd_settings_panel1 fieldset,
     #gd_settings_panel1 table {
         width: 50%;
     }
+
+    .gd-on-translations .gp-content h2 a.glossary-link:last-child,
+    .gd-on-translations .gp-content h2 a.glossary-link+a.glossary-link {
+        margin-right: 54px;
+    }
+
+    .gd-on-translations .gp-content h2 a.glossary-link:last-child::after,
+    .gd-on-translations .gp-content h2 a.glossary-link+a.glossary-link::after {
+        margin-left: 27px;
+    }
+
 }
 
 @media screen and (min-width: 1200px) {
@@ -710,6 +759,35 @@ code {
 
     #gd_settings_panel1 label {
         max-width: 750px;
+    }
+}
+
+
+@media screen and (max-width: 1679.98px) {
+
+    .gd-on-translations .gp-content h2 a.glossary-link:last-child,
+    .gd-on-translations .gp-content h2 a.glossary-link+a.glossary-link {
+        margin-right: 14px;
+    }
+
+    .gd-on-translations .gp-content h2 a.glossary-link:last-child::after,
+    .gd-on-translations .gp-content h2 a.glossary-link+a.glossary-link::after {
+        margin-left: 7px;
+    }
+
+    .gd-on-translations h2 {
+        font-size: 19px;
+        line-height: 21px;
+    }
+
+    .gd-on-translations .gp-content h2 a.glossary-link {
+        font-size: 15px;
+    }
+}
+
+@media screen and (max-width: 1439.98px) {
+    .gd-on-translations h2 {
+        font-size: 15px;
     }
 }
 

--- a/js/glotdict-functions.js
+++ b/js/glotdict-functions.js
@@ -99,7 +99,7 @@ function gd_add_project_links() {
 	if ( jQuery( '.gp-content .breadcrumb li' ).length > 3 && jQuery( '.gp-content .breadcrumb li:last-child a' ).length > 0 ) {
 		let lang = jQuery( '.gp-content .breadcrumb li:last-child a' ).attr( 'href' ).split( '/' );
 		lang = sanitize_value( lang[lang.length - 3] );
-		jQuery( jQuery( '.gp-content h2' )[0] ).prepend( `<a class="glossary-link" style="float:right;padding-left:5px;margin-left:5px;border-left: 1px solid black;" href="https://translate.wordpress.org/locale/${lang}/default" target="_blank" rel="noreferrer noopener">${jQuery( '.gp-content .breadcrumb li:last-child a' ).text()} Projects to Translate</a>` + '<a class="glossary-link" style="float:right;" href="https://translate.wordpress.org/stats" target="_blank" rel="noreferrer noopener">Translation Global Status</a>' );
+		jQuery( jQuery( '.gp-content h2' )[0] ).prepend( `<a class="glossary-link" style="float:right;" href="https://translate.wordpress.org/locale/${lang}/default" target="_blank" rel="noreferrer noopener">${jQuery( '.gp-content .breadcrumb li:last-child a' ).text()} Projects to Translate</a>` + '<a class="glossary-link" style="float:right;" href="https://translate.wordpress.org/stats" target="_blank" rel="noreferrer noopener">Translation Global Status</a>' );
 	}
 }
 


### PR DESCRIPTION
As we add a lot of things in the h2 of the translation pages, I think we need to improve the readability of this title.
See the images before after. The responsive is managed to reduce the spaces or the sizes according to the breakpoints.

Chrome before/after:

![chrome](https://user-images.githubusercontent.com/17084006/133880342-d88a92be-f831-4d85-8409-e0ebd0ac3591.jpg)

Firefox before/after:

![firefox](https://user-images.githubusercontent.com/17084006/133880433-1f7494ff-ae54-4559-9a46-9d316bf220c2.jpg)

(sorry if there is a difference in screen width between the before / after, it should not be taken into account)