### PR TITLE
Fix visible selector query

### DIFF
--- a/js/glotdict-functions.js
+++ b/js/glotdict-functions.js
@@ -561,5 +561,5 @@ function gd_build_sticky_header() {
  * @returns {void}
  */
 function gd_copy_visible_original_string() {
-	gd_copy_to_clipboard( document.querySelector('.editor:visible .original-raw' ).innerHTML );
+	gd_copy_to_clipboard( document.querySelector( '.editor[style="display: table-row;"] .original-raw' ).innerHTML );
 }


### PR DESCRIPTION
My mistake here in this commit:  https://github.com/Mte90/GlotDict/pull/336/commits/dbef7316a5a2355858e7a02322596921d8a81639 😁 (Sorry!)

`:visible` seems not to be a valid native selector, throwing an error and should be replaced.

![image](https://user-images.githubusercontent.com/65488419/134464871-565ffea7-83f4-427b-a0ac-4fc477bdee3a.png)

GP adds inline `style="display: table-row;"` for the current opened editor, so `.editor[style="display: table-row;"]` should be equivalent with `.editor:visible`

Tested this and it's working as expected. More testing is welcome.