### PR TITLE
Plurals for Consistency suggestions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,7 @@
 {
 	"env": {
 		"browser": true,
-		"es6": true,
+		"es2017": true,
 		"webextensions": true
 	},
 	"globals": {

--- a/css/style.css
+++ b/css/style.css
@@ -252,18 +252,69 @@ button.gd-approve strong {
     color: #c3c0c0;
 }
 
-.gd_get_consistency {
-    margin-left: 10px !important;
-}
-
-.translation-suggestion__translation.index,
+.gd-consistency .index,
 .consistency-count {
     padding: 0 4px;
     color: #666;
+    font-size: 0.9em;
 }
 
 .consistency-count {
     font-size: 0.8em;
+}
+
+li.consistency-header-index {
+    font-size: 0.9em;
+    color: grey;
+    border-bottom: 1px dashed #cabfbf;
+}
+
+.consistency-header-index .copy-full-alternative,
+.consistency-header-index .consistency-count {
+    float: right;
+}
+
+.consistency-header-index .copy-full-alternative {
+    box-shadow: none !important;
+}
+
+.gte-warning {
+    margin-top: -5px;
+    padding-left: 15px;
+    padding-bottom: 10px;
+}
+
+.gd-suggestions-list {
+    list-style: none;
+    padding-left: 0 !important;
+}
+
+.gd-suggestions-list li + li {
+    margin-top: 5px;
+}
+
+.gd-consistency .space {
+    background: #cbcdce;
+    white-space: pre-wrap;
+    opacity: .4;
+}
+
+.gd-arrow,
+.gte-warning,
+.consistency-count {
+    color: rgb(119, 0, 0);
+}
+
+.gd-suggestions-list.with-plural .gd-arrow {
+    float:right;
+}
+
+.suggestions__other-languages .suggestions-list,
+.suggestions__translation-memory .suggestions-list,
+.gd-suggestions-list {
+    max-height: 300px !important;
+    overflow: auto;
+    -webkit-overflow-scrolling: touch;
 }
 
 @-webkit-keyframes gd-ripple-out {

--- a/js/glotdict-consistency.js
+++ b/js/glotdict-consistency.js
@@ -14,35 +14,35 @@ function gd_quicklinks() {
 			'type':       'button',
 			'class':      `gd_quicklinks_copy with-tooltip ${( gd_quicklinks_copy_state ) ? 'active' : 'inactive'}`,
 			'aria-label': 'Click this and another to copy',
-		}
+		},
 	);
 	gd_quicklinks_copy.append(
 		gd_create_element( 'span', { 'class': 'screen-reader-text' }, 'Copy toggle' ),
-		gd_create_element( 'span', { 'class': 'dashicons dashicons-clipboard', 'aria-hidden': 'true' } )
+		gd_create_element( 'span', { 'class': 'dashicons dashicons-clipboard', 'aria-hidden': 'true' } ),
 	);
 	const gd_quicklinks_separator = gd_create_element(
 		'span',
 		{
 			'class':       `gd_quicklinks_plus dashicons ${( gd_quicklinks_copy_state ) ? 'dashicons-plus' : 'separator'}`,
 			'aria-hidden': 'true',
-		}
+		},
 	);
 	const gd_quicklinks_permalink = gd_create_element( 'button', { 'class': 'gd_quicklinks_item gd_quicklinks_permalink with-tooltip', 'aria-label': 'Permalink to translation' } );
 	gd_quicklinks_permalink.append(
 		gd_create_element( 'span', { 'class': 'screen-reader-text' }, 'Permalink to translation' ),
-		gd_create_element( 'span', { 'class': 'dashicons dashicons-admin-links', 'aria-hidden': 'true' } )
+		gd_create_element( 'span', { 'class': 'dashicons dashicons-admin-links', 'aria-hidden': 'true' } ),
 	);
 
 	const gd_quicklinks_history = gd_create_element( 'button', { 'class': 'gd_quicklinks_item gd_quicklinks_history with-tooltip', 'aria-label': 'Translation History' } );
 	gd_quicklinks_history.append(
 		gd_create_element( 'span', { 'class': 'screen-reader-text' }, 'Translation History' ),
-		gd_create_element( 'span', { 'class': 'dashicons dashicons-backup', 'aria-hidden': 'true' } )
+		gd_create_element( 'span', { 'class': 'dashicons dashicons-backup', 'aria-hidden': 'true' } ),
 	);
 
 	const gd_quicklinks_consistency = gd_create_element( 'button', { 'class': 'gd_quicklinks_item gd_quicklinks_consistency with-tooltip', 'aria-label': 'View original in consistency tool' } );
 	gd_quicklinks_consistency.append(
 		gd_create_element( 'span', { 'class': 'screen-reader-text' }, 'View original in consistency tool' ),
-		gd_create_element( 'span', { 'class': 'dashicons dashicons-list-view', 'aria-hidden': 'true' } )
+		gd_create_element( 'span', { 'class': 'dashicons dashicons-list-view', 'aria-hidden': 'true' } ),
 	);
 
 	gd_quicklinks_output.append(
@@ -50,7 +50,7 @@ function gd_quicklinks() {
 		gd_quicklinks_separator,
 		gd_quicklinks_permalink,
 		gd_quicklinks_history,
-		gd_quicklinks_consistency
+		gd_quicklinks_consistency,
 	);
 
 	gd_add_elements( '.editor-panel__right .panel-header', 'beforeend', gd_quicklinks_output );

--- a/js/glotdict-consistency.js
+++ b/js/glotdict-consistency.js
@@ -1,7 +1,7 @@
 let gd_quicklinks_copy_state = 'true' === localStorage.getItem( 'gd_quicklinks_copy_state' );
 let gd_quicklinks_window = { 'closed': true };
 
-if ( 'undefined' !== typeof $gp_editor_options ) {
+if ( gd_user.is_on_translations ) {
 	gd_quicklinks();
 	gd_consistency();
 }
@@ -96,66 +96,181 @@ function gd_toggle_quicklinks_copy() {
 }
 
 function gd_consistency() {
-	const gd_consistency_output = gd_create_element( 'details', { 'class': 'gd_consistency suggestions__translation-consistency', 'open': 'open' } );
+	if ( document.querySelector( '.gd-get-consistency' ) !== null ) {
+		return;
+	}
+	const gd_consistency_output = gd_create_element( 'details', { 'class': 'gd-consistency suggestions__translation-consistency', 'open': 'open' } );
 	const gd_consistency_summary = gd_create_element( 'summary', { }, 'Suggestions from Consistency' );
-	const gd_consistency_button = gd_create_element( 'button', { 'class': 'gd_get_consistency' }, 'View Consistency suggestions' );
-	gd_consistency_output.append( gd_consistency_summary, gd_consistency_button );
+	const gd_consistency_loading = document.querySelector( '.suggestions__loading-indicator' );
 
-	gd_add_elements( '.editor-panel__left .suggestions-wrapper', 'beforeend', gd_consistency_output );
-	gd_add_evt_listener( 'click', '.gd_get_consistency', gd_show_consistency );
+	gd_consistency_output.append( gd_consistency_summary );
+	gd_consistency_loading && gd_consistency_output.append( gd_consistency_loading );
+	gd_add_elements( '.editor-panel__left .suggestions-wrapper .suggestions__translation-memory', 'afterEnd', gd_consistency_output );
+
+	$gp.editor.show = ( function( original ) {
+		return function() {
+			original.apply( $gp.editor, arguments );
+			const gd_consistency = $gp.editor.current[ 0 ].querySelector( '.gd-consistency' );
+			gd_consistency && gd_do_consistency( gd_consistency );
+		}
+	} )( $gp.editor.show );
 }
 
-function gd_show_consistency( event ) {
-	event.target.textContent = 'Loading...';
-	const consistency_url = event.target.closest( '.editor-panel' ).querySelectorAll( '.button-menu__dropdown li a' )[ 2 ].href;
+async function gd_do_consistency( el ) {
+	if ( el.classList.contains( 'initialized' ) ) {
+		return;
+	}
+	el.classList.add( 'initialized' );
+	const consistency_url = el.closest( '.editor-panel' ).querySelectorAll( '.button-menu__dropdown li a' )[ 2 ].href.replace( 'consistency?search', 'consistency/?search' );
+	const consistency_page = await gd_consistency_get_page( consistency_url );
+	if ( false === consistency_page ) {
+		gd_consistency_end( el, 'Error loading suggestions. Try refreshing.' );
+		return;
+	}
 
-	fetch( consistency_url )
-		.then( consistency_response => consistency_response.text() )
-		.then( consistency_response => {
-			const consistency_parser = new DOMParser();
-			const consistency_page = consistency_parser.parseFromString( consistency_response, 'text/html' );
-			const consistency_translations = consistency_page.querySelectorAll( '.consistency-table tbody th strong' );
-			let translations_count, unique_translation_count;
+	const consistency_alternatives = consistency_page.querySelectorAll( '.consistency-table tbody tr th strong' );
 
-			if ( 1 === consistency_translations.length ) {
-				unique_translation_count = consistency_page.querySelectorAll( 'tr' ).length - 2;
-				unique_translation_count = ` (${unique_translation_count} time${( unique_translation_count > 1 ) ? 's' : ''})`;
-			} else {
-				translations_count = consistency_page.querySelectorAll( '.translations-unique small' );
-			}
+	if ( ! consistency_alternatives.length ) {
+		gd_consistency_end( el, 'No suggestions.' );
+		return;
+	}
 
-			let gd_consistency_suggestions;
+	const current_string = {
+		'translated_texts':   [],
+		'form_names':         [],
+		'alternatives_count': gd_consistency_get_alternative_count( consistency_page, consistency_alternatives.length ),
+	};
 
-			if ( consistency_translations.length ) {
-				let gd_consistency_item,
-					gd_consistency_item_div,
-					gd_consistency_item_translation,
-					gd_consistency_item_index,
-					gd_consistency_item_count,
-					gd_consistency_item_raw,
-					gd_consistency_item_button;
+	const this_panel_content = el.closest( '.panel-content' );
+	this_panel_content.querySelectorAll( 'textarea' ).forEach( ( translation_form ) => {
+		current_string.translated_texts[ current_string.translated_texts.length ] = translation_form.value;
+	} );
 
-				gd_consistency_suggestions = gd_create_element( 'ul', { class: 'suggestions-list' } );
+	const translation_forms = this_panel_content.querySelectorAll( '.translation-form-list .translation-form-list__tab' );
+	translation_forms.forEach( ( form ) => {
+		current_string.form_names[ current_string.form_names.length ] = form.textContent.trim();
+	} );
 
-				for ( let i = 0; i < consistency_translations.length; i++ ) {
-					gd_consistency_item = document.createElement( 'li' );
-					gd_consistency_item_div = gd_create_element( 'div', { 'class': 'translation-suggestion with-tooltip', 'role': 'button', 'aria-pressed': 'false', 'aria-label': 'Copy translation', 'tabindex': '0' } );
-					gd_consistency_item_translation = gd_create_element( 'span', { 'class': 'translation-suggestion__translation' }, consistency_translations[ i ].textContent );
-					gd_consistency_item_index = gd_create_element( 'span', { 'class': 'translation-suggestion__translation index' }, `${i + 1}: ` );
-					gd_consistency_item_count = gd_create_element( 'span', { 'class': 'consistency-count' }, ( 1 === consistency_translations.length ) ? unique_translation_count : translations_count[ i ].textContent );
-					gd_consistency_item_raw = gd_create_element( 'span', { 'class': 'translation-suggestion__translation-raw', 'aria-hidden': 'true' }, consistency_translations[ i ].textContent );
-					gd_consistency_item_button = gd_create_element( 'button', { 'type': 'button', 'class': 'copy-suggestion' }, 'Copy' );
-					gd_consistency_item_translation.prepend( gd_consistency_item_index );
-					gd_consistency_item_translation.append( gd_consistency_item_count );
-					gd_consistency_item_div.append( gd_consistency_item_translation, gd_consistency_item_raw, gd_consistency_item_button );
-					gd_consistency_item.append( gd_consistency_item_div );
-					gd_consistency_suggestions.append( gd_consistency_item );
-				}
-			} else {
-				gd_consistency_suggestions = 'No suggestions.';
-			}
-			event.target.before( gd_consistency_suggestions );
-			event.target.parentNode.removeChild( event.target );
-		} )
-		.catch( error => console.log( error ) );
+	const gd_consistency_suggestions = gd_create_element( 'ul', { class: 'gd-suggestions-list' } );
+	const arrow = document.createElement( 'span' );
+	arrow.title = 'This is the current translation used for this string.';
+	arrow.className = 'gd-arrow';
+	arrow.textContent = ' ⟵';
+
+	for ( let consistency_alternatives_i = 0; consistency_alternatives_i < consistency_alternatives.length; consistency_alternatives_i++ ) {
+		const alternative = {
+			'forms_text': [ consistency_alternatives[ consistency_alternatives_i ].textContent ],
+			'i':          consistency_alternatives_i,
+			'arrow':      arrow,
+		};
+		if ( translation_forms.length > 1 ) {
+			const string_page = await gd_consistency_get_page( consistency_alternatives[ consistency_alternatives_i ].parentNode.parentNode.nextSibling.querySelectorAll( 'td .meta a' )[ 1 ].href.replace( '?filters', '/?filters' ) );
+			const consistency_textareas = string_page.querySelectorAll( '.translation-wrapper .textareas textarea' );
+
+			consistency_textareas.forEach( ( textarea, i ) => {
+				alternative.forms_text[ i ] = textarea.value;
+			} );
+
+			const gd_consistency_item_header = gd_create_element( 'li', { 'class': 'consistency-header-index' }, `#${consistency_alternatives_i + 1}` );
+			gd_consistency_item_header.append(
+				gd_create_element( 'button', { 'type': 'button', 'class': 'copy-full-alternative', 'data-alternative_id': consistency_alternatives_i }, 'Copy' ),
+				gd_create_element( 'span', { 'class': 'consistency-count' }, current_string.alternatives_count[ consistency_alternatives_i ] ),
+			);
+			gd_consistency_suggestions.append( gd_consistency_item_header );
+			gd_consistency_suggestions.classList.add( 'with-plural' );
+		}
+		gd_consistency_suggestions.append( gd_consistency_add_alternative( alternative, current_string ) );
+	}
+	if ( gd_user.is_editor && consistency_alternatives.length > 1 ) {
+		const warning = document.createElement( 'div' );
+		warning.className = 'gte-warning';
+		warning.textContent = `${consistency_alternatives.length} current different translations!`;
+		gd_consistency_suggestions.insertAdjacentElement( 'afterBegin', warning );
+	}
+
+	el.append( gd_consistency_suggestions );
+	( translation_forms.length > 1 ) &&	gd_consistency_format_for_plural( this_panel_content );
+	gd_consistency_end( el );
+}
+
+async function gd_consistency_get_page( url ) {
+	try {
+		const res = await fetch( url, { headers: new Headers( { 'User-agent': 'Mozilla/4.0 Custom User Agent' } ) } );
+		const txt = await res.text();
+		const consistency_parser = new DOMParser();
+		return consistency_parser.parseFromString( txt, 'text/html' );
+	} catch ( error ) {
+		return false;
+	}
+}
+
+function gd_consistency_get_alternative_count( consistency_page, consistency_count ) {
+	if ( 1 === consistency_count ) {
+		const unique_alternative_count = consistency_page.querySelectorAll( 'tr' ).length - 2;
+		return [ ` (${unique_alternative_count} time${( unique_alternative_count > 1 ) ? 's' : ''})` ];
+	}
+	const alternatives_count = [];
+	consistency_page.querySelectorAll( '.translations-unique small' ).forEach( ( el ) => {
+		alternatives_count[ alternatives_count.length ] = el.textContent;
+	} );
+	return alternatives_count;
+}
+
+function gd_consistency_add_alternative ( alternative, current_string ) {
+	const space_span = gd_create_element( 'span', { 'class': 'space' }, ' ' );
+	const consistency_alternative_fragment = document.createDocumentFragment();
+	alternative.forms_text.forEach( ( form_text, form_text_i ) => {
+		const is_this_one = ( form_text === current_string.translated_texts[ form_text_i ] ) ? alternative.arrow.cloneNode( true ) : '';
+		const gd_consistency_item = document.createElement( 'li' );
+		const gd_consistency_item_div = gd_create_element( 'div', { 'class': 'translation-suggestion with-tooltip', 'role': 'button', 'aria-pressed': 'false', 'aria-label': 'Copy translation', 'tabindex': '0' } );
+		const gd_consistency_item_translation = gd_create_element( 'span', { 'class': 'translation-suggestion__translation' } );
+		const alternative_as_words_fragment = document.createDocumentFragment();
+		const alternative_as_words = form_text.split( ' ' );
+		alternative_as_words.forEach( ( word, word_i ) => {
+			alternative_as_words_fragment.appendChild( document.createTextNode( word ) );
+			( word_i < alternative_as_words.length - 1 ) && alternative_as_words_fragment.append( space_span.cloneNode( true ) );
+		} );
+		gd_consistency_item_translation.append( alternative_as_words_fragment, is_this_one );
+		const meta_info = ( current_string.form_names.length ) ? `${current_string.form_names[ form_text_i ]}: ` : `${alternative.i + 1}: `;
+		const gd_consistency_item_meta = gd_create_element( 'span', { 'class': 'translation-suggestion__translation index' }, meta_info );
+		const gd_consistency_item_raw = gd_create_element( 'span', { 'class': `translation-suggestion__translation-raw consistency_alternative__${alternative.i}_${form_text_i}`, 'aria-hidden': 'true' }, form_text );
+		const gd_consistency_item_button = gd_create_element( 'button', { 'type': 'button', 'class': 'copy-suggestion' }, 'Copy' );
+		gd_consistency_item_translation.prepend( gd_consistency_item_meta );
+		( 0 === current_string.form_names.length ) && gd_consistency_item_translation.append( gd_create_element( 'span', { 'class': 'consistency-count' }, current_string.alternatives_count[ alternative.i ] ) );
+		gd_consistency_item_div.append( gd_consistency_item_translation, gd_consistency_item_raw, gd_consistency_item_button );
+		gd_consistency_item.append( gd_consistency_item_div );
+		consistency_alternative_fragment.appendChild( gd_consistency_item );
+	} );
+	return consistency_alternative_fragment;
+}
+
+function gd_consistency_format_for_plural( this_panel_content ) {
+	gd_add_evt_listener( 'click', '.copy-full-alternative', gd_consistency_copy_full_alternative );
+	this_panel_content.querySelectorAll( '.gd-consistency .copy-suggestion' ).forEach( ( el ) => {
+		el.parentNode.removeChild( el )
+	} );
+	this_panel_content.querySelectorAll( '.gd-consistency .translation-suggestion' ).forEach( ( el ) => {
+		el.classList.remove( 'translation-suggestion' );
+	} );
+	this_panel_content.querySelectorAll( '.gd-consistency .with-tooltip' ).forEach( ( el ) => {
+		el.classList.remove( 'with-tooltip' );
+	} );
+}
+
+function gd_consistency_copy_full_alternative( event ) {
+	const panel_content = event.target.closest( '.panel-content' );
+	const alternative_id = event.currentTarget.dataset.alternative_id;
+	panel_content.querySelectorAll( 'textarea' ).forEach( ( textarea, i ) => {
+		const suggestion_form = panel_content.querySelector( `.consistency_alternative__${alternative_id}_${i}` );
+		if ( suggestion_form ) {
+			textarea.value = suggestion_form.textContent;
+		}
+	} );
+	panel_content.querySelector( ' .textareas.active textarea' ).focus();
+}
+
+function gd_consistency_end( el, error = false ) {
+	error && el.append( error );
+	const loading = el.querySelector( '.suggestions__loading-indicator' );
+	loading && el.removeChild( loading );
 }

--- a/js/glotdict-consistency.js
+++ b/js/glotdict-consistency.js
@@ -1,7 +1,7 @@
 let gd_quicklinks_copy_state = 'true' === localStorage.getItem( 'gd_quicklinks_copy_state' );
 let gd_quicklinks_window = { 'closed': true };
 
-if ( gd_user.is_on_translations ) {
+if ( typeof $gp_editor_options !== 'undefined' ) {
 	gd_quicklinks();
 	gd_consistency();
 }
@@ -183,7 +183,7 @@ async function gd_do_consistency( el ) {
 		}
 		gd_consistency_suggestions.append( gd_consistency_add_alternative( alternative, current_string ) );
 	}
-	if ( gd_user.is_editor && consistency_alternatives.length > 1 ) {
+	if ( '1' === $gp_editor_options.can_approve && consistency_alternatives.length > 1 ) {
 		const warning = document.createElement( 'div' );
 		warning.className = 'gte-warning';
 		warning.textContent = `${consistency_alternatives.length} current different translations!`;

--- a/js/glotdict-consistency.js
+++ b/js/glotdict-consistency.js
@@ -110,14 +110,16 @@ function gd_consistency() {
 	$gp.editor.show = ( function( original ) {
 		return function() {
 			original.apply( $gp.editor, arguments );
-			const gd_consistency = $gp.editor.current[ 0 ].querySelector( '.gd-consistency' );
-			gd_consistency && gd_do_consistency( gd_consistency );
+			gd_do_consistency( $gp.editor.current[ 0 ].querySelector( '.gd-consistency' ) );
 		}
 	} )( $gp.editor.show );
+
+	// If the current table has only one editor, already opened, load suggestions for it.
+	( $gp.editor.current ) && gd_do_consistency( $gp.editor.current[ 0 ].querySelector( '.gd-consistency' ) );
 }
 
 async function gd_do_consistency( el ) {
-	if ( el.classList.contains( 'initialized' ) ) {
+	if ( ! el || el.classList.contains( 'initialized' ) ) {
 		return;
 	}
 	el.classList.add( 'initialized' );

--- a/js/glotdict.js
+++ b/js/glotdict.js
@@ -115,11 +115,11 @@ jQuery( '.gp-content' ).on( 'click', '.discard-glotdict', function( e ) {
 } );
 
 if ( gd_user.is_on_translations && gd_get_setting( 'autocopy_string_on_translation_opened' ) ) {
-	jQuery( $gp.editor.table ).on( 'click', 'a.edit', function() {
-		setTimeout(() => { gd_copy_visible_original_string(); }, 400);
+	jQuery( $gp.editor.table ).on( 'click', 'a.edit', () => {
+		setTimeout( () => { gd_copy_visible_original_string(); }, 400 );
 	} );
-	jQuery( $gp.editor.table ).on( 'dblclick', 'tr.preview td', function() {
-		setTimeout(() => { gd_copy_visible_original_string(); }, 400);
+	jQuery( $gp.editor.table ).on( 'dblclick', 'tr.preview td', () => {
+		setTimeout( () => { gd_copy_visible_original_string(); }, 400 );
 	} );
 }
 

--- a/js/init.js
+++ b/js/init.js
@@ -18,7 +18,7 @@ fetch( changelog )
 					data['changelog'] = ( null !== lastChange ) ? lastChange[1] : '';
 					localStorage.setItem( 'gd_extension_status', JSON.stringify( data ) );
 				}
-			}
+			},
 		);
 	} )
 	.then( () => script( jsScripts ) )

--- a/js/init.js
+++ b/js/init.js
@@ -1,4 +1,4 @@
-const jsScripts = [ 'jquery.bind-first', 'dompurify', 'keymaster', 'glotdict-locales', 'glotdict-functions', 'glotdict-settings', 'glotdict-hotkey', 'glotdict-validation', 'glotdict-column', 'glotdict-meta', 'glotdict-bulk', 'glotdict-notices', 'glotdict', 'glotdict-consistency' ];
+const jsScripts = [ 'jquery.bind-first', 'dompurify', 'keymaster', 'glotdict-locales', 'glotdict-functions', 'glotdict-settings', 'glotdict-hotkey', 'glotdict-validation', 'glotdict-column', 'glotdict-meta', 'glotdict-bulk', 'glotdict-notices', 'glotdict-consistency', 'glotdict' ];
 
 // Get extension informations
 const changelog = chrome.runtime.getURL( 'CHANGELOG.md' );

--- a/js/init.js
+++ b/js/init.js
@@ -1,4 +1,4 @@
-const jsScripts = [ 'jquery.bind-first', 'dompurify', 'keymaster', 'glotdict-locales', 'glotdict-functions', 'glotdict-settings', 'glotdict-hotkey', 'glotdict-validation', 'glotdict-column', 'glotdict-meta', 'glotdict-bulk', 'glotdict-notices', 'glotdict-consistency', 'glotdict' ];
+const jsScripts = [ 'jquery.bind-first', 'dompurify', 'keymaster', 'glotdict-locales', 'glotdict-functions', 'glotdict-settings', 'glotdict-hotkey', 'glotdict-validation', 'glotdict-column', 'glotdict-meta', 'glotdict-bulk', 'glotdict-notices', 'glotdict', 'glotdict-consistency' ];
 
 // Get extension informations
 const changelog = chrome.runtime.getURL( 'CHANGELOG.md' );


### PR DESCRIPTION
1. In order to use async/await we need to upgrade to es2017. Fixing various es2017 things.
2. In order to use `gd_user` object we need to load glotdict script earlier. 
3. Implements plurals for consistency and a message for GTEs/PTEs if there are multiple consistency alternatives.

Testing needed.
Fixes: #330 


# Demos:

## Singular string - contributor view
![demo_singular_contributor](https://user-images.githubusercontent.com/65488419/136196220-588e03fa-0d66-491d-bb08-8478b2fdf7e9.gif)

## Singular string - PTE/GTE view
![demo_singular_PTE-GTE](https://user-images.githubusercontent.com/65488419/136196221-0dd921ed-c6bd-496b-9c55-2e879b540623.gif)

## Plural string - contributor view
![demo_plural_contributor](https://user-images.githubusercontent.com/65488419/136196213-c7b38d02-17f3-4681-8e4e-6096c0dbe7b4.gif)

## Plural string - PTE/GTE view
![demo_plural_PTE-GTE](https://user-images.githubusercontent.com/65488419/136196218-0f5be8d6-b37f-44e1-a8e8-2c5b112a85dc.gif)

## Plural string - a very long list
![demo_plural_long_list](https://user-images.githubusercontent.com/65488419/136196217-60ada1cd-346b-4610-9a29-e31eb1d14542.gif)



