### PR TITLE
Anonymous author filter

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -20,6 +20,7 @@
 		"gd_add_project_links": true,
 		"gd_add_review_button": true,
 		"gd_add_scroll_buttons": true,
+		"gd_anonymous": true,
 		"gd_build_sticky_header": true,
 		"gd_copy_visible_original_string": true,
 		"gd_copy_to_clipboard": true,

--- a/css/style.css
+++ b/css/style.css
@@ -100,6 +100,10 @@ table.translations tr.preview.has-original-copy,
     }
 }
 
+#gd_search_anonymous {
+    margin-right: 5px;
+}
+
 .gd-language-picker-container {
     display: inline-block;
 }

--- a/js/glotdict-functions.js
+++ b/js/glotdict-functions.js
@@ -563,3 +563,26 @@ function gd_build_sticky_header() {
 function gd_copy_visible_original_string() {
 	gd_copy_to_clipboard( document.querySelector( '.editor[style="display: table-row;"] .original-raw' ).innerHTML );
 }
+
+/**
+ * Adds an anonimous check next to the author filter field
+ * @returns {void}
+ */
+function gd_anonymous() {
+	const user_filter_el = document.getElementById( 'filters[user_login]' );
+	if ( ! user_filter_el ) {
+		return;
+	}
+	const anonymous = document.createElement( 'div' );
+	const anonymous_input = gd_create_element( 'input', { 'type': 'checkbox', 'id': 'gd_search_anonymous' } );
+	const anonymous_label = gd_create_element( 'label', { 'for': 'gd_search_anonymous' }, 'Anonymous author' );
+	anonymous.append( anonymous_input, anonymous_label );
+	user_filter_el.insertAdjacentElement( 'afterend', anonymous );
+	anonymous_input.addEventListener( 'click', ( event ) => {
+		if ( event.target.checked ) {
+			document.getElementById( 'filters[user_login]' ).value = 'anonymous';
+			return;
+		}
+		document.getElementById( 'filters[user_login]' ).value = '';
+	} );
+}

--- a/js/glotdict.js
+++ b/js/glotdict.js
@@ -151,3 +151,4 @@ gd_to_top.addEventListener( 'click', ( e ) => {
 gd_user.is_connected && gd_build_sticky_header();
 
 gd_wait_table_alter();
+gd_anonymous();


### PR DESCRIPTION
Adds an Anonymous author checkbox for user filter.

After [this changeset on dot org](https://meta.trac.wordpress.org/changeset/11154), this is a missing feature. This is to filter translations without an author, from the plugin's author first import, that didn't go trouogh any GTE/PTE review process.

Introduced recently, in this 
![gd_anonymous_btn](https://user-images.githubusercontent.com/65488419/136213755-54f6b031-19bf-40d2-ac21-c714f7624716.gif)

Fixes: #332 
