### PR TITLE
Non-translatable items

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -321,6 +321,49 @@ li.consistency-header-index {
     -webkit-overflow-scrolling: touch;
 }
 
+.gd_notranslate {
+    margin-bottom: 15px;
+    color: #666666;
+}
+
+.gd_notranslate div:before {
+    content: '\25B6';
+    font-size: 0.8em;
+    padding-right: 5px;
+    color: #666666;
+}
+
+.gd_notranslate a {
+    display: inline-block;
+    padding: 1px 6px;
+    border: 1px solid #b4b4b4;
+    margin: 5px 3px 0;
+    cursor: pointer;
+    color: #5d5c5c !important;
+    text-decoration: none;
+    background-color: #ebf5fd;
+    word-break: break-word;
+}
+
+.gd_notranslate a.used {
+    opacity: 0.5;
+}
+
+.editor .notranslate {
+    background-color: #ebf5fd;
+    cursor: pointer;
+}
+
+.editor .notranslate:hover .notranslate,
+.editor .notranslate:hover {
+    background-color: #c9e3f9;
+}
+
+
+.gd_notranslate_copy_all {
+    float:right;
+}
+
 @-webkit-keyframes gd-ripple-out {
     0% {
         box-shadow: 0 0 6px 6px rgba(0, 115, 170, .3);


### PR DESCRIPTION
- Highlight non-translatable strings in original editor
- Click on any non-translatable item in original editor
- Display real time usage of non-translatable strings
- Insert individual or Copy all non-translatable items

This can fit multiple workflows of translating: copy pasting all placeholders, inserting them one by one from the original above or from the area below, where they get greyed out if they are used.

These items are marked by GlotPress, so they should be fine.

Currently using a [workaround](https://gist.github.com/vlad-timotei/9fc62e9c1b7a40d4708a3b0345ad2a22) for plurals, but when it will be fixed upstream on w.org I will remove it.

Fixes: #331 

![gd_demo_notranslatable](https://user-images.githubusercontent.com/65488419/136266284-007f6981-85a8-4000-82cf-cb6a5addd054.gif)


