### PR TITLE
Change Alt+C shortcut

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -27,6 +27,7 @@
 		"gd_create_element": true,
 		"gd_curly_apostrophe_highlight": true,
 		"gd_current_locale_first": true,
+		"gd_do_consistency": true,
 		"gd_extension": true,
 		"gd_get_lang_consistency": true,
 		"gd_get_setting": true,

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ PS: If you are using NoScript or Privacy Badger enable wordpress.org domain or e
 | Dismiss all validation warnings | Ctrl+Shift+D |
 | Force suggest or Force save translation | Ctrl+Shift+Enter |
 | Fuzzy | Ctrl+Shift+F |
-| Load consistency suggestions | Alt+C |
+| Load all consistency suggestions | Alt+C |
 | Open next string editor | Page Down |
 | Open previous string editor | Page Up |
 | Reject | Ctrl+Shift+R |

--- a/js/glotdict-hotkey.js
+++ b/js/glotdict-hotkey.js
@@ -110,9 +110,7 @@ function gd_hotkeys() {
 		return false;
 	} );
 	key( 'alt+c', () => {
-		if ( jQuery( '.editor:visible' ).length > 0 ) {
-			jQuery( '.editor:visible .gd_get_consistency' ).trigger( 'click' );
-		}
+		document.querySelectorAll( '.gd-consistency' ).forEach( ( el ) => { gd_do_consistency( el ); } );
 		return false;
 	} );
 }

--- a/js/glotdict-settings.js
+++ b/js/glotdict-settings.js
@@ -63,7 +63,7 @@ function gd_generate_settings_panel() {
 		'Dismiss all validation warnings':                            'Ctrl+Shift+D',
 		'Force suggest or Force save translation':                    'Ctrl+Shift+Enter',
 		'Fuzzy':                                                      'Ctrl+Shift+F',
-		'Load consistency suggestions':                               'Alt+C',
+		'Load all consistency suggestions':                           'Alt+C',
 		'Open next string editor':                                    'Page Down',
 		'Open previous string editor':                                'Page Up',
 		'Reject':                                                     'Ctrl+Shift+R',


### PR DESCRIPTION
Since #342 we load consistency suggestions on editor opening, so Alt+C now loads all consistency suggestions from the current page instead.