### PR TITLE
Feature | Dropdown Pagination

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -43,6 +43,7 @@
 		"gd_mark_old_strings": true,
 		"gd_notranslate": true,
 		"gd_non_breaking_space_highlight": true,
+		"gd_pagination": true,
 		"gd_quicklinks": true,
 		"gd_run_review": true,
 		"gd_selected_count": true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 2.0.4
 
-* Enhancement: re-add GD features to rows after saving
+* Enhancement: Re-add GD features to rows after saving
+* Enhancement: Dropdown Pagination
 
 # 2.0.3
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ PS: If you are using NoScript or Privacy Badger enable wordpress.org domain or e
 * Notices counts for Approved, Rejected, Fuzzied, Submitted and Selected rows
 * Daily update of the list of locales
 * Anonymous author search filter
+* Dropdown Pagination
 * Many hotkeys and shortcuts
 
 ## Hotkeys

--- a/css/style.css
+++ b/css/style.css
@@ -636,6 +636,10 @@ li.consistency-header-index {
     margin: 10px 0;
 }
 
+.gd-pagination {
+    margin: 4px 6px;    
+}
+
 .gp-content .gd_changelog h3 {
     font-size: 1.6rem;
     color: #1d2327;

--- a/js/glotdict-functions.js
+++ b/js/glotdict-functions.js
@@ -593,3 +593,52 @@ function gd_anonymous() {
 		document.getElementById( 'filters[user_login]' ).value = '';
 	} );
 }
+
+/**
+ * Adds dropdown pagination
+ * @returns {void}
+ */
+function gd_pagination() {
+	const default_pagination = document.querySelectorAll( '.paging' );
+	if ( ! default_pagination.length ) {
+		return;
+	}
+
+	const pages = default_pagination[ 0 ].querySelectorAll( 'a' );
+	if ( ! pages.length ) {
+		return;
+	}
+
+	const last_page = {};
+	if ( '→' === pages[ pages.length - 1 ].textContent ) {
+		last_page.id = parseInt( pages[ pages.length - 2 ].textContent );
+		last_page.url = pages[ pages.length - 2 ].href;
+	} else {
+		last_page.id = parseInt( pages[ pages.length - 1 ].textContent ) + 1;
+		last_page.url = pages[ pages.length - 1 ].href;
+	}
+
+	const gd_pagination = document.createElement( 'select' );
+	const option = document.createElement( 'option' );
+	gd_pagination.className = 'gd-pagination';
+
+	const current = parseInt( default_pagination[ 0 ].querySelector( '.current' ).textContent );
+
+	for ( let i = 1; i <= last_page.id; i++ ) {
+		const this_option = option.cloneNode( true );
+		this_option.value = i;
+		this_option.textContent = i;
+		if ( i === current ) {
+			this_option.className = 'current-page';
+		}
+		gd_pagination.appendChild( this_option );
+	}
+
+	default_pagination.forEach( default_pagination_instance => {
+		const this_gd_pagination = gd_pagination.cloneNode( true );
+		this_gd_pagination.addEventListener( 'change', ( ev ) => { window.location = last_page.url.replace( /page=\d+/, `page=${ev.target.value}` ); } );
+		default_pagination_instance.insertAdjacentElement( 'beforeend', this_gd_pagination );
+	} );
+
+	document.querySelectorAll( '.gd-pagination .current-page' ).forEach( el => { el.selected = true; } );
+}

--- a/js/glotdict.js
+++ b/js/glotdict.js
@@ -155,3 +155,4 @@ gd_user.is_connected && gd_build_sticky_header();
 gd_wait_table_alter();
 gd_localize_date();
 gd_anonymous();
+gd_pagination();


### PR DESCRIPTION
Adding a dropdown pagination feature next to current default pagination, for easier access to page outside the range displayed in the current navigation list.


![gd_pagination_feature](https://user-images.githubusercontent.com/65488419/143771943-dc674be6-207b-4bf5-a738-6ef188f10ff5.gif)

Works fine with sticky header: 

![gd_pagination_feature_UI](https://user-images.githubusercontent.com/65488419/143771955-26bacf1d-5143-48bd-ab60-1cda77e9752e.gif)

Also works for the footer pagination.

![gd_pagination_feature_footer](https://user-images.githubusercontent.com/65488419/143772007-1b591bd9-eb48-4cec-bf81-32753ac01b09.gif)

