### PR TITLE
Enhancement  | Consider glossary words occurrences

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -43,6 +43,7 @@
 		"gd_mark_old_strings": true,
 		"gd_notranslate": true,
 		"gd_non_breaking_space_highlight": true,
+		"gd_occurrences": true,
 		"gd_pagination": true,
 		"gd_quicklinks": true,
 		"gd_run_review": true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Enhancement: Re-add GD features to rows after saving
 * Enhancement: Dropdown Pagination
+* Enhancement: Check all glossary word occurrences on validation
 
 # 2.0.3
 

--- a/js/glotdict-functions.js
+++ b/js/glotdict-functions.js
@@ -642,3 +642,24 @@ function gd_pagination() {
 
 	document.querySelectorAll( '.gd-pagination .current-page' ).forEach( el => { el.selected = true; } );
 }
+
+/**
+ * Counts the occurrences of a subString in a string
+ * Algorithm by Vitim.us at https://gist.github.com/victornpb/7736865
+ *
+ * @param {String} string
+ * @param {String} subString
+ * @return {number}
+ */
+function gd_occurrences( string, subString ) {
+	string = `${string.toLowerCase()}`;
+	subString = `${subString.toLowerCase()}`;
+	if ( subString.length <= 0 ) { return ( string.length + 1 ); }
+	let n = 0, pos = 0;
+	const step = subString.length;
+	while ( true ) {
+		pos = string.indexOf( subString, pos );
+		if ( pos >= 0 ) { ++n; pos += step; } else { break; }
+	}
+	return n;
+}

--- a/js/glotdict-validation.js
+++ b/js/glotdict-validation.js
@@ -42,16 +42,28 @@ function gd_search_glossary_on_translation( e, selector ) {
 	jQuery( selector ).each( function() {
 		const $editor = jQuery( this );
 		const translation = jQuery( 'textarea', $editor ).val();
+		const glossary_words = jQuery( '.glossary-word', $editor ).map( function() {return this.textContent;} ).get();
+		const words_with_warning = [];
 		jQuery( '.glossary-word', $editor ).each( function() {
+			const glossary_word = this.textContent.toLowerCase();
+			if ( words_with_warning.includes( glossary_word ) ) {
+				return true;
+			}
+			const glossary_word_occurrence = glossary_words.filter( word => word.toLowerCase() === glossary_word ).length;
 			const translations = jQuery( this ).data( 'translations' );
 			let reset = '';
+			let count = '';
 			const term = jQuery( this ).html();
 			jQuery( translations ).each( ( index ) => {
 				if ( 'N/A' === translations[index].translation ) {
 					return true;
 				}
-				if ( -1 === translation.search( new RegExp( translations[index].translation, 'gi' ) ) ) {
-					reset = `${reset}"<b>${translations[index].translation}</b>", `;
+				const translation_word_occurrence = gd_occurrences( translation, translations[index].translation );
+				if ( translation_word_occurrence < glossary_word_occurrence ) {
+					words_with_warning.push( glossary_word );
+					reset = `${reset}“<b>${translations[index].translation}</b>“, `;
+					const diff = glossary_word_occurrence - translation_word_occurrence;
+					count = `${diff} time${diff > 1 ? 's' : ''}`;
 				} else {
 					reset = '';
 					return false;
@@ -64,7 +76,7 @@ function gd_search_glossary_on_translation( e, selector ) {
 				if ( translations.length > 1 ) {
 					message = 'The translation does not contain any of the suggested translations';
 				}
-				jQuery( '.textareas', $editor ).prepend( gd_get_warning( `${message} (${reset}) for the term "<i>${term}</i>"`, discard ) );
+				jQuery( '.textareas', $editor ).prepend( gd_get_warning( `${message} (${reset}) for the term “<i>${term}</i>“ ${count}`, discard ) );
 			}
 		} );
 	} );


### PR DESCRIPTION
Fixes: #353

This counts how many times a glossary original word is used in the original and then when checking the translation, it validates the translation if the translation contains the suggested translation at least the same number of times as in original.

_This DOES NOT fix an issue with validation glossary for the plural strings._ 

**Needs testing.**

![image](https://user-images.githubusercontent.com/65488419/147414951-f3fd6b53-5481-411b-857e-f10d2a667426.png)

