### PR TITLE
find a solution for german and dutch locales…

### DIFF
--- a/js/glotdict-functions.js
+++ b/js/glotdict-functions.js
@@ -159,8 +159,8 @@ function gd_add_scroll_buttons() {
 
 	let slug = gd_get_locale_slug( gd_get_lang(), 'locale' );
 	const lang = gd_get_lang();
-	slug = slug.replace( 'de', 'de/default' );
-	slug = slug.replace( 'nl', 'nl/default' );
+	slug = slug.replace( /de/, 'de/default' );
+	slug = slug.replace( /nl/, 'nl/default' );
 	for ( const regex in locations ) {
 		const position = document.querySelector( 'table' );
 		const acquired = ( RegExp( locations[regex] ) ).test( window.location.href );

--- a/js/glotdict-functions.js
+++ b/js/glotdict-functions.js
@@ -157,9 +157,10 @@ function gd_add_scroll_buttons() {
 		appsRegex:     'https:\\/\\/translate.wordpress.org\\/projects\\/apps\\/[^\\/]+\\/[^\\/]+\\/$',
 	};
 
-	const slug = gd_get_locale_slug( gd_get_lang(), 'locale' );
+	let slug = gd_get_locale_slug( gd_get_lang(), 'locale' );
 	const lang = gd_get_lang();
-
+	slug = slug.replace( 'de', 'de/default' );
+	slug = slug.replace( 'nl', 'nl/default' );
 	for ( const regex in locations ) {
 		const position = document.querySelector( 'table' );
 		const acquired = ( RegExp( locations[regex] ) ).test( window.location.href );


### PR DESCRIPTION
… which have same slug for formal forms so the "scroll to locale" button didn't work fix#369