### PR TITLE
fix broken styles after GlotPress Update

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -20,11 +20,11 @@ table.translations tr.preview.has-glotdict .original::before {
 }
 
 table.translations tr.preview.has-glotdict th+.priority+.original::before {
-    margin-left: calc(-.5em - 32px);
+    margin-left: calc(-.5em - 49px);
 }
 
 table.translations tr.preview.has-glotdict.has-warnings th+.priority+.original::before {
-    margin-left: calc(-.5em - 34px);
+    margin-left: calc(-.5em - 50px);
 }
 
 .has-old-string td:nth-last-child(2),
@@ -100,6 +100,11 @@ table.translations tr.preview.has-original-copy,
     }
 }
 
+#gd-glossary-link,
+#gd-guide-link{
+	margin: 0 1px;
+}
+
 #gd_search_anonymous {
     margin-right: 5px;
 }
@@ -161,8 +166,18 @@ table.translations tr.preview.has-original-copy,
     border-left: 3px solid #dc3232;
 }
 
-button[class*="gd-"] strong {
+.actions+td button[class*="gd-"] strong {
     display: inline-block;
+	margin-left:-10px;
+}
+
+.actions+td button.gd-button{
+	-ms-flex-pack: center!important;
+	    justify-content: center!important;
+	padding: 14px 2px !important;
+	width: 80px !important;
+	margin: 1px 0 !important;
+	min-height: 28px !important;
 }
 
 .gd-btn-action {
@@ -515,7 +530,7 @@ li.consistency-header-index {
     max-width: 100vw;
     right: 0;
     z-index: -1;
-    margin-top: -22px;
+    margin-top: -19px;
     height: 55px;
 }
 
@@ -572,7 +587,8 @@ li.consistency-header-index {
     padding-right: 10px;
 }
 
-.gd_settings_panels input[type="checkbox"] {
+.gp-content .gd_settings_panels input[type=checkbox],
+.gp-content .gd_settings_panels input[type=radio] {
     margin-right: 6px;
     margin-left: -20px;
     vertical-align: -1px;
@@ -627,10 +643,6 @@ li.consistency-header-index {
 .gd_settings_panels {
     background: #e5f5fa;
     padding: 10px;
-}
-
-.gd_settings_tabs {
-    margin-top: 22px;
 }
 
 .gd_settings__radio3,
@@ -762,18 +774,20 @@ li.consistency-header-index {
     box-sizing: border-box;
 }
 
-.gd-on-translations .gp-content .bulk-actions input.button,
-.gd-on-translations .gp-content input.button.gd-review {
-    vertical-align: top;
-    height: auto;
-    margin: 0 5px;
-    padding: 10px;
-    font-size: 14px;
+#bulk-actions-toolbar-top{
+	float:left !important;
+}
 
+.gd-on-translations .gp-content input.button.gd-review {
+    margin: 0 5px;
+}
+
+#gd-sticky-header .paging{
+	width: 100%;
+	margin-top: .5em !important;
 }
 
 #gd-toggle-header {
-    float: right;
     margin-left: 40px;
     margin-top: -1px;
 }
@@ -834,9 +848,22 @@ code {
 }
 
 .gd-on-translations .gp-content h2 {
-    font-size: 19px;
-    font-weight: 500;
-    line-height: 20px;
+	display: block!important;
+	width: 100%!important;
+    font-size: 19px!important;
+    font-weight: 500!important;
+    line-height: 20px!important;
+	padding: 10px 8px 9px!important;
+	border-radius: 5px!important;
+	background-color: rgb(0 115 170 / 5%)!important;
+}
+
+#gd_title_links{
+	float: right;
+	display: -ms-flexbox;
+	display: flex;
+	-ms-flex-direction: row-reverse;
+	    flex-direction: row-reverse;
 }
 
 .gd-on-translations .gp-content h2 a.glossary-link {

--- a/js/glotdict-functions.js
+++ b/js/glotdict-functions.js
@@ -647,7 +647,7 @@ function gd_build_sticky_header() {
 
 	const titleLinks = document.querySelector( '#gd_title_links' );
 	const pluginGlossaryLink = document.querySelector( '.gp-heading>h2+a.glossary-link' );
-	pluginGlossaryLink.textContent = 'Plugin Glossary';
+	pluginGlossaryLink.textContent = 'Project Glossary';
 	titleLinks.append( pluginGlossaryLink );
 
 	const title = document.querySelector( '.gp-content .breadcrumb+h2' );

--- a/js/glotdict-functions.js
+++ b/js/glotdict-functions.js
@@ -99,7 +99,10 @@ function gd_add_project_links() {
 	if ( jQuery( '.gp-content .breadcrumb li' ).length > 3 && jQuery( '.gp-content .breadcrumb li:last-child a' ).length > 0 ) {
 		let lang = jQuery( '.gp-content .breadcrumb li:last-child a' ).attr( 'href' ).split( '/' );
 		lang = sanitize_value( lang[lang.length - 3] );
-		jQuery( jQuery( '.gp-content h2' )[0] ).prepend( `<a class="glossary-link" style="float:right;" href="https://translate.wordpress.org/locale/${lang}/default" target="_blank" rel="noreferrer noopener">${jQuery( '.gp-content .breadcrumb li:last-child a' ).text()} Projects to Translate</a>` + '<a class="glossary-link" style="float:right;" href="https://translate.wordpress.org/stats" target="_blank" rel="noreferrer noopener">Translation Global Status</a>' );
+		const titleLinksContainer = document.createElement( 'SPAN' );
+		titleLinksContainer.id = 'gd_title_links';
+		document.querySelector( '.gp-content h2' ).appendChild( titleLinksContainer );
+		jQuery( '#gd_title_links' ).append( `<a class="glossary-link" href="https://translate.wordpress.org/locale/${lang}/default" target="_blank" rel="noreferrer noopener">${jQuery( '.gp-content .breadcrumb li:last-child a' ).text()} Projects to Translate</a>` + '<a class="glossary-link" href="https://translate.wordpress.org/stats" target="_blank" rel="noreferrer noopener">Translation Global Status</a>' );
 	}
 }
 
@@ -300,13 +303,13 @@ function gd_add_official_links_to_filters() {
 	const gd_glossary_link = document.createElement('A');
 	gd_glossary_link.id = 'gd-glossary-link';
 	gd_glossary_link.href = gd_glossary.glossary_url;
-	gd_glossary_link.textContent = 'Global glossary';
+	gd_glossary_link.textContent = 'Global Glossary';
 	gd_glossary_link.target = '_blank';
 
 	const gd_guide_link = document.createElement('A');
 	gd_guide_link.id = 'gd-guide-link';
 	gd_guide_link.target = '_blank';
-	gd_guide_link.textContent = '' !== gd_glossary.guide.title ? gd_glossary.guide.title : 'Style guide';
+	gd_guide_link.textContent = '' !== gd_glossary.guide.title ? gd_glossary.guide.title : 'Style Guide';
 
 	if ( '' !== gd_glossary.guide.url ) {
 		gd_guide_link.href = gd_glossary.guide.url;
@@ -641,6 +644,11 @@ function gd_build_sticky_header() {
 	if ( gd_header_is_sticky ) {
 		document.body.classList.add( 'gd-header-is-sticky' );
 	}
+
+	const titleLinks = document.querySelector( '#gd_title_links' );
+	const pluginGlossaryLink = document.querySelector( '.gp-heading>h2+a.glossary-link' );
+	pluginGlossaryLink.textContent = 'Plugin Glossary';
+	titleLinks.append( pluginGlossaryLink );
 
 	const title = document.querySelector( '.gp-content .breadcrumb+h2' );
 	const filter_toolbar = document.querySelector( '.filter-toolbar' );


### PR DESCRIPTION
Fixes #380
I took the liberty of renaming "Glossary" to "Project glossary" since the glossary related functionality will add a link to the actual Global Glossary.
I also gave a light background to the H2 title which was removed on GlotPress because we no longer spotted the elements.
