### PR TITLE
Glossary  / Style Guide Links refinements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.0.6
+
+* Enhancement: Glossary and custom Style Guide links
+* Fix: UI adjustments for GlotPress 3.0 compatibility
+
 # 2.0.5
 
 * Fix: More UI adjustements to the new Translate.WordPress UI

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ PS: If you are using NoScript or Privacy Badger enable wordpress.org domain or e
 * Daily update of the list of locales
 * Anonymous author search filter
 * Dropdown Pagination
+* Custom Style Guide link
 * Many hotkeys and shortcuts
 
 ## Hotkeys

--- a/js/glotdict-functions.js
+++ b/js/glotdict-functions.js
@@ -303,13 +303,13 @@ function gd_add_official_links_to_filters() {
 	const gd_glossary_link = document.createElement('A');
 	gd_glossary_link.id = 'gd-glossary-link';
 	gd_glossary_link.href = gd_glossary.glossary_url;
-	gd_glossary_link.textContent = 'Global Glossary';
+	gd_glossary_link.textContent = 'Locale Glossary';
 	gd_glossary_link.target = '_blank';
 
 	const gd_guide_link = document.createElement('A');
 	gd_guide_link.id = 'gd-guide-link';
 	gd_guide_link.target = '_blank';
-	gd_guide_link.textContent = '' !== gd_glossary.guide.title ? gd_glossary.guide.title : 'Style Guide';
+	gd_guide_link.textContent = '' !== gd_glossary.guide.title ? gd_glossary.guide.title : 'Translation Style Guide';
 
 	if ( '' !== gd_glossary.guide.url ) {
 		gd_guide_link.href = gd_glossary.guide.url;

--- a/js/glotdict-functions.js
+++ b/js/glotdict-functions.js
@@ -103,6 +103,13 @@ function gd_add_project_links() {
 		titleLinksContainer.id = 'gd_title_links';
 		document.querySelector( '.gp-content h2' ).appendChild( titleLinksContainer );
 		jQuery( '#gd_title_links' ).append( `<a class="glossary-link" href="https://translate.wordpress.org/locale/${lang}/default" target="_blank" rel="noreferrer noopener">${jQuery( '.gp-content .breadcrumb li:last-child a' ).text()} Projects to Translate</a>` + '<a class="glossary-link" href="https://translate.wordpress.org/stats" target="_blank" rel="noreferrer noopener">Translation Global Status</a>' );
+	
+		const titleLinks = document.querySelector( '#gd_title_links' );
+		const pluginGlossaryLink = document.querySelector( '.gp-heading>h2+a.glossary-link' );
+		if ( pluginGlossaryLink ) {
+			pluginGlossaryLink.textContent = 'Project Glossary';
+			titleLinks.append( pluginGlossaryLink );
+		}
 	}
 }
 
@@ -643,13 +650,6 @@ function gd_build_sticky_header() {
 	let gd_header_is_sticky = 'true' === localStorage.getItem( 'gd_header_is_sticky' );
 	if ( gd_header_is_sticky ) {
 		document.body.classList.add( 'gd-header-is-sticky' );
-	}
-
-	const titleLinks = document.querySelector( '#gd_title_links' );
-	const pluginGlossaryLink = document.querySelector( '.gp-heading>h2+a.glossary-link' );
-	if ( pluginGlossaryLink ) {
-		pluginGlossaryLink.textContent = 'Project Glossary';
-		titleLinks.append( pluginGlossaryLink );
 	}
 
 	const title = document.querySelector( '.gp-content .breadcrumb+h2' );

--- a/js/glotdict-settings.js
+++ b/js/glotdict-settings.js
@@ -283,15 +283,15 @@ function gd_set_panel3_settings( panel3 ) {
 	const styleGuide = document.createElement( 'DIV' );
 	fragment3.appendChild( styleGuide );
 	styleGuide.classList.add( 'gd-settings-tab3__style-guide' );
-	styleGuide.appendChild( document.createElement( 'H4' ) ).appendChild( document.createTextNode( 'Customize Translation Style Guide link' ) );
-	styleGuide.appendChild( document.createElement( 'DIV' ) ).appendChild( document.createTextNode( 'By default, Translation Style Guide links to the locale handbook - locale.wordpress.org/team/handbook - also a recommended resource for your team. However, as a GTE you can customize this link to point to a certain resource your team uses, such as a sub-page of the handbook or even an external page.' ) );
+	styleGuide.appendChild( document.createElement( 'H4' ) ).appendChild( document.createTextNode( 'Customize Style Guide link' ) );
+	styleGuide.appendChild( document.createElement( 'DIV' ) ).appendChild( document.createTextNode( 'By default, Style Guide links to the locale handbook - locale.wordpress.org/team/handbook - also a recommended resource for your team. However, as a GTE you can customize this link to point to a certain resource your team uses, such as a sub-page of the handbook or even an external page.' ) );
 	styleGuide.appendChild( document.createElement( 'P' ) ).appendChild( document.createTextNode( 'To do so, fill in this form, click on  “Generate HTML”, then copy and paste it into the Description field of your locale glossary.' ) );
 	const styleGuideForm = document.createDocumentFragment();
 
 	const styleGuideURLLabel = document.createElement( 'LABEL' );
 	styleGuideURLLabel.htmlFor = 'gd-styleguide-url';
 	styleGuideURLLabel.classList.add( 'gd-settings-label' );
-	styleGuideURLLabel.textContent = 'Enter an URL for the Translation Style Guide link:';
+	styleGuideURLLabel.textContent = 'Enter an URL for the Style Guide link:';
 
 	const styleGuideURLInput = document.createElement( 'INPUT' );
 	styleGuideURLInput.type = 'text';
@@ -304,7 +304,7 @@ function gd_set_panel3_settings( panel3 ) {
 	const styleGuideMenuLabel = document.createElement( 'LABEL' );
 	styleGuideMenuLabel.htmlFor = 'gd-styleguide-menu';
 	styleGuideMenuLabel.classList.add( 'gd-settings-label' );
-	styleGuideMenuLabel.textContent = 'Enter a title for the Translation Style Guide link:';
+	styleGuideMenuLabel.textContent = 'Enter a title for the Style Guide link:';
 
 	const styleGuideMenuInput = document.createElement( 'INPUT' );
 	styleGuideMenuInput.type = 'text';

--- a/js/glotdict-settings.js
+++ b/js/glotdict-settings.js
@@ -67,8 +67,8 @@ function gd_generate_settings_panel() {
 			'settings': {
 				'no_non_breaking_space':                    'Hide highlights for non-breaking spaces.',
 				'autocopy_string_on_translation_opened':    'Auto-copy original to clipboard on editor opening.',
-				'autosubmit_bulk_copy_from_original':       'Auto-save after "Copy from Original" bulk action.*',
-				'force_autosubmit_bulk_copy_from_original': 'Ignore auto-save warnings after "Copy from Original".*',
+				'autosubmit_bulk_copy_from_original':       'Auto-save after “Copy from Original” bulk action.*',
+				'force_autosubmit_bulk_copy_from_original': 'Ignore auto-save warnings after “Copy from Original”.*',
 			},
 		},
 	];
@@ -278,45 +278,33 @@ function gd_get_setting( key ) {
  */
 function gd_set_panel3_settings( panel3 ) {
 	const fragment3 = document.createDocumentFragment();
-	fragment3.appendChild( document.createElement( 'H3' ) ).appendChild( document.createTextNode( 'Locale-specific settings' ) );
-	fragment3.appendChild( document.createElement( 'P' ) ).appendChild( document.createTextNode( 'As a GTE, you can customize some GlotDict settings for all users in your locale. First step is to have a global glossary.' ) );
+	fragment3.appendChild( document.createElement( 'H3' ) ).appendChild( document.createTextNode( 'Locale specific settings' ) );
+	fragment3.appendChild( document.createElement( 'DIV' ) ).appendChild( document.createTextNode( 'GlotDict links to the Locale Glossary in the filters toolbar, so it\'s highly recommended that your locale has a Glossary.' ) );
 	const styleGuide = document.createElement( 'DIV' );
 	fragment3.appendChild( styleGuide );
 	styleGuide.classList.add( 'gd-settings-tab3__style-guide' );
-	styleGuide.appendChild( document.createElement( 'H4' ) ).appendChild( document.createTextNode( 'Style guide link' ) );
-	styleGuide.appendChild( document.createElement( 'P' ) ).appendChild( document.createTextNode( 'GlotDict add 2 links in filters toolbar: Global glossary link, and Style guide link.' ) );
-	styleGuide.appendChild( document.createElement( 'P' ) ).appendChild( document.createTextNode( 'If you don\'t already have a global glossary for your locale, we recommend that you create one. Style guide link points to the locale handbook. If you don\'t have one, we also advise you to create one. But maybe you would prefer this link to point to a sub-page of the handbook that describes the style rules, or even an external page like a google doc or a github page… well that\'s possible. We are going to use the description field of the glossary for this.' ) );
-	styleGuide.appendChild( document.createElement( 'P' ) ).appendChild( document.createTextNode( 'Fill in the following values, then click on the button which will generate an HTML code that you must copy and paste into the Description field of the glossary. And voilà !' ) );
+	styleGuide.appendChild( document.createElement( 'H4' ) ).appendChild( document.createTextNode( 'Customize Translation Style Guide link' ) );
+	styleGuide.appendChild( document.createElement( 'DIV' ) ).appendChild( document.createTextNode( 'By default, Translation Style Guide links to the locale handbook - locale.wordpress.org/team/handbook - also a recommended resource for your team. However, as a GTE you can customize this link to point to a certain resource your team uses, such as a sub-page of the handbook or even an external page.' ) );
+	styleGuide.appendChild( document.createElement( 'P' ) ).appendChild( document.createTextNode( 'To do so, fill in this form, click on  “Generate HTML”, then copy and paste it into the Description field of your locale glossary.' ) );
 	const styleGuideForm = document.createDocumentFragment();
 
 	const styleGuideURLLabel = document.createElement( 'LABEL' );
 	styleGuideURLLabel.htmlFor = 'gd-styleguide-url';
 	styleGuideURLLabel.classList.add( 'gd-settings-label' );
-	styleGuideURLLabel.textContent = 'Enter an URL for the style guide link';
+	styleGuideURLLabel.textContent = 'Enter an URL for the Translation Style Guide link:';
 
 	const styleGuideURLInput = document.createElement( 'INPUT' );
-	styleGuideURLInput.type = 'url';
+	styleGuideURLInput.type = 'text';
 	styleGuideURLInput.size = 100;
 	styleGuideURLInput.name = 'gd-styleguide-url';
 	styleGuideURLInput.id = 'gd-styleguide-url';
 	styleGuideURLInput.placeholder = 'https://en-gb.wordpress.org/translations/';
-
-	const styleGuideTextLabel = document.createElement( 'LABEL' );
-	styleGuideTextLabel.htmlFor = 'gd-styleguide-text';
-	styleGuideTextLabel.classList.add( 'gd-settings-label' );
-	styleGuideTextLabel.textContent = 'Enter a text for the style guide link on glossary page';
-
-	const styleGuideTextInput = document.createElement( 'INPUT' );
-	styleGuideTextInput.type = 'text';
-	styleGuideTextInput.size = 60;
-	styleGuideTextInput.name = 'gd-styleguide-text';
-	styleGuideTextInput.id = 'gd-styleguide-text';
-	styleGuideTextInput.placeholder = 'typographical rules used for the translation of WordPress in UK English';
+	styleGuideURLInput.setAttribute( 'style', 'width: 98%!important' );
 
 	const styleGuideMenuLabel = document.createElement( 'LABEL' );
 	styleGuideMenuLabel.htmlFor = 'gd-styleguide-menu';
 	styleGuideMenuLabel.classList.add( 'gd-settings-label' );
-	styleGuideMenuLabel.textContent = 'Enter a title for the style guide link menu on translations pages';
+	styleGuideMenuLabel.textContent = 'Enter a title for the Translation Style Guide link:';
 
 	const styleGuideMenuInput = document.createElement( 'INPUT' );
 	styleGuideMenuInput.type = 'text';
@@ -333,20 +321,20 @@ function gd_set_panel3_settings( panel3 ) {
 
 	const styleGuideHTMLCode = document.createElement( 'TEXTAREA' );
 	styleGuideHTMLCode.id = 'gd-styleguide-html';
+	styleGuideHTMLCode.placeholder = 'Copy and paste this generated HTML in the Description field of your locale glossary.';
 	styleGuideHTMLCode.rows = 5;
-	styleGuideHTMLCode.cols = 33;
+	styleGuideHTMLCode.setAttribute( 'style', 'width: 98%!important' );
 
-	styleGuideForm.append( styleGuideURLLabel, styleGuideURLInput, styleGuideTextLabel, styleGuideTextInput, styleGuideMenuLabel, styleGuideMenuInput, styleGuideGeneratorButton, styleGuideHTMLCode );
+	styleGuideForm.append( styleGuideMenuLabel, styleGuideMenuInput, styleGuideURLLabel, styleGuideURLInput, styleGuideGeneratorButton, styleGuideHTMLCode );
 	fragment3.appendChild( styleGuideForm );
 	panel3.appendChild( fragment3 );
 
 	styleGuideGeneratorButton.addEventListener( 'click', () => {
 		styleGuideURLInput.style.border = '' === styleGuideURLInput.value ? 'red 1px solid' : 'green 1px solid';
-		styleGuideTextInput.style.border = '' === styleGuideTextInput.value ? 'red 1px solid' : 'green 1px solid';
 		styleGuideMenuInput.style.border = '' === styleGuideMenuInput.value ? 'red 1px solid' : 'green 1px solid';
-		if ( '' === styleGuideURLInput.value || '' === styleGuideTextInput.value || '' === styleGuideMenuInput.value ) {
+		if ( '' === styleGuideURLInput.value || '' === styleGuideMenuInput.value ) {
 			return;
 		}
-		styleGuideHTMLCode.value = `<a href="${styleGuideURLInput.value}" id="gd-guide-link" data-title="${styleGuideMenuInput.value}">${styleGuideTextInput.value}</a>`;
+		styleGuideHTMLCode.value = `<a href="${styleGuideURLInput.value}" id="gd-guide-link" data-title="${styleGuideMenuInput.value}">${styleGuideMenuInput.value}</a>`;
 	} );
 }


### PR DESCRIPTION
Some refinements for the Glosary Data feature, as per huddle with @webaxones 
- use Locale Glossary and Project Glossary terminology
- use translation Style Guide terminology
- simplify form to generate custom HTML for the Glossary description
- other design adjustments

+ update readme & changelog

+ move logic inside gd_add_project_links