### PR TITLE
fix glossary links display bug.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -872,11 +872,13 @@ code {
     margin-top: 0;
 }
 
+.glossary-links .glossary-link:first-child,
 .gd-on-translations .gp-content h2 a.glossary-link:last-child,
 .gd-on-translations .gp-content h2 a.glossary-link+a.glossary-link {
     margin-right: 26px;
 }
 
+.glossary-links .glossary-link:first-child::after,
 .gd-on-translations .gp-content h2 a.glossary-link:last-child::after,
 .gd-on-translations .gp-content h2 a.glossary-link+a.glossary-link::after {
     position: absolute;
@@ -909,10 +911,12 @@ code {
     }
 
     .gd-on-translations .gp-content h2 a.glossary-link:last-child,
+    .gd-on-translations .gp-content h2 .glossary-links a.glossary-link:first-child,
     .gd-on-translations .gp-content h2 a.glossary-link+a.glossary-link {
         margin-right: 54px;
     }
 
+	.glossary-links .glossary-link:first-child::after,
     .gd-on-translations .gp-content h2 a.glossary-link:last-child::after,
     .gd-on-translations .gp-content h2 a.glossary-link+a.glossary-link::after {
         margin-left: 27px;
@@ -960,11 +964,13 @@ code {
 
 @media screen and (max-width: 1679.98px) {
 
+	.glossary-links .glossary-link:first-child,
     .gd-on-translations .gp-content h2 a.glossary-link:last-child,
     .gd-on-translations .gp-content h2 a.glossary-link+a.glossary-link {
         margin-right: 14px;
     }
 
+	.glossary-links .glossary-link:first-child::after,
     .gd-on-translations .gp-content h2 a.glossary-link:last-child::after,
     .gd-on-translations .gp-content h2 a.glossary-link+a.glossary-link::after {
         margin-left: 7px;

--- a/js/glotdict-functions.js
+++ b/js/glotdict-functions.js
@@ -102,14 +102,15 @@ function gd_add_project_links() {
 		const titleLinksContainer = document.createElement( 'SPAN' );
 		titleLinksContainer.id = 'gd_title_links';
 		document.querySelector( '.gp-content h2' ).appendChild( titleLinksContainer );
-		jQuery( '#gd_title_links' ).append( `<a class="glossary-link" href="https://translate.wordpress.org/locale/${lang}/default" target="_blank" rel="noreferrer noopener">${jQuery( '.gp-content .breadcrumb li:last-child a' ).text()} Projects to Translate</a>` + '<a class="glossary-link" href="https://translate.wordpress.org/stats" target="_blank" rel="noreferrer noopener">Translation Global Status</a>' );
+		jQuery( '#gd_title_links' ).append( `<a class="glossary-link" href="https://translate.wordpress.org/locale/${lang}/default" target="_blank" rel="noreferrer noopener">${jQuery( '.gp-content .breadcrumb li:last-child a' ).text()} Projects</a>` + '<a class="glossary-link" href="https://translate.wordpress.org/stats" target="_blank" rel="noreferrer noopener">Translation Global Status</a>' );
 	
 		const titleLinks = document.querySelector( '#gd_title_links' );
-		const pluginGlossaryLink = document.querySelector( '.gp-heading>h2+a.glossary-link' );
-		if ( pluginGlossaryLink ) {
-			pluginGlossaryLink.textContent = 'Project Glossary';
-			titleLinks.append( pluginGlossaryLink );
+		const glossaryLinks = document.querySelector( '.gp-heading>h2+.glossary-links' );
+		if ( glossaryLinks ) {
+			titleLinks.append( glossaryLinks );
 		}
+		const glossaryLinksSeparator = document.querySelector( '#gd_title_links .glossary-links .separator' );
+		glossaryLinksSeparator.remove();
 	}
 }
 
@@ -307,12 +308,6 @@ function gd_extract_glossary_data( glossary_data ) {
  * @returns void
  */
 function gd_add_official_links_to_filters() {
-	const gd_glossary_link = document.createElement('A');
-	gd_glossary_link.id = 'gd-glossary-link';
-	gd_glossary_link.href = gd_glossary.glossary_url;
-	gd_glossary_link.textContent = 'Locale Glossary';
-	gd_glossary_link.target = '_blank';
-
 	const gd_guide_link = document.createElement('A');
 	gd_guide_link.id = 'gd-guide-link';
 	gd_guide_link.target = '_blank';
@@ -333,11 +328,11 @@ function gd_add_official_links_to_filters() {
 	if ( ! filter_toolbars_div ) {
 		return;
 	}
-	if ( '' !== gd_glossary.glossary_url && gd_glossary_link ) {
-		filter_toolbars_div.append( gp_separator, gd_glossary_link );
+	if ( '' !== gd_glossary.glossary_url ) {
+		filter_toolbars_div.append( gp_separator );
 	}
 	if ( gd_guide_link && ( '' !== gd_glossary.guide.url || '' !== gd_glossary.handbook_url ) ) {
-		filter_toolbars_div.append( gp_separator.cloneNode( true ), gd_guide_link );
+		filter_toolbars_div.append( gd_guide_link );
 	}
 }
 


### PR DESCRIPTION
Replace glossary links inside h2 bar
Remove duplicated glossary link from filters
Remove "To Translate" from the link "French (France) Projects To Translate" to save space since there is 1 more link
Fixes #386