### PR TITLE
Fixes to comply with the w.org Beta Testing program fix #391 fix #392

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.0.9
+
+* Fix: Fixes to comply with the w.org Beta Testing program [Fixes #391]
 # 2.0.8
 
 * Fix: Edge case for some locales without glossary configured

--- a/js/glotdict-validation.js
+++ b/js/glotdict-validation.js
@@ -45,7 +45,7 @@ function gd_search_glossary_on_translation( e, selector ) {
 
 	jQuery( selector ).each( function() {
 		const $editor = jQuery( this );
-		const translations = jQuery( 'textarea', $editor );
+		const translations = jQuery( 'textarea.foreign-text', $editor );
 		const originals = jQuery( '.original, .original-text', $editor );
 
 		let original_index = SINGULAR;


### PR DESCRIPTION
In gd_search_glossary_on_translation function we target the translation textarea without any css class selector cause there was only one textarea.
With the new feature, another textarea is added in the editor part.
This PR uses the ".foreign-text" selector to target the textarea.