### PR TITLE
Mv3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "background": {
-    "scripts": ["js/background.js"]
+    "service_worker": "js/background.js"
   },
   "content_scripts": [
     {
@@ -16,29 +16,35 @@
     }
   ],
   "web_accessible_resources": [
-    "js/glotdict-locales.js",
-    "js/glotdict.js",
-    "js/glotdict-functions.js",
-    "js/glotdict-hotkey.js",
-    "js/glotdict-validation.js",
-    "js/glotdict-notices.js",
-    "js/glotdict-bulk.js",
-    "js/glotdict-column.js",
-    "js/glotdict-meta.js",
-    "js/glotdict-consistency.js",
-    "js/glotdict-settings.js",
-    "js/keymaster.js",
-    "js/jquery.bind-first.js",
-    "js/dompurify.js",
-    "CHANGELOG.md",
-    "icons/icon-48.png",
-    "css/style.css",
-    "js/init.js"
-  ],
+		{
+			"resources": [ 
+				"js/glotdict-locales.js",
+        "js/glotdict.js",
+        "js/glotdict-functions.js",
+        "js/glotdict-hotkey.js",
+        "js/glotdict-validation.js",
+        "js/glotdict-notices.js",
+        "js/glotdict-bulk.js",
+        "js/glotdict-column.js",
+        "js/glotdict-meta.js",
+        "js/glotdict-consistency.js",
+        "js/glotdict-settings.js",
+        "js/keymaster.js",
+        "js/jquery.bind-first.js",
+        "js/dompurify.js",
+        "CHANGELOG.md",
+        "icons/icon-48.png",
+        "css/style.css",
+        "js/init.js"
+			],
+			"matches": [ "https://translate.wordpress.org/*" ]
+		}
+		
+	],
   "version": "2.0.11",
   "description": "Improve the workflow on translate.wordpress.org",
   "homepage_url": "https://github.com/Mte90/GlotDict",
-  "manifest_version": 2,
+  "manifest_version": 3,
   "icons": {
     "48": "icons/icon-48.png",
     "128": "icons/icon-128.png",

--- a/manifest.v2.json
+++ b/manifest.v2.json
@@ -1,0 +1,48 @@
+{
+  "background": {
+    "scripts": ["js/background.js"]
+  },
+  "content_scripts": [
+    {
+      "js": [
+        "js/init.js"
+      ],
+      "css": [
+        "css/style.css"
+      ],
+      "matches": [
+        "*://translate.wordpress.org/*"
+      ]
+    }
+  ],
+  "web_accessible_resources": [
+    "js/glotdict-locales.js",
+    "js/glotdict.js",
+    "js/glotdict-functions.js",
+    "js/glotdict-hotkey.js",
+    "js/glotdict-validation.js",
+    "js/glotdict-notices.js",
+    "js/glotdict-bulk.js",
+    "js/glotdict-column.js",
+    "js/glotdict-meta.js",
+    "js/glotdict-consistency.js",
+    "js/glotdict-settings.js",
+    "js/keymaster.js",
+    "js/jquery.bind-first.js",
+    "js/dompurify.js",
+    "CHANGELOG.md",
+    "icons/icon-48.png",
+    "css/style.css",
+    "js/init.js"
+  ],
+  "version": "2.0.11",
+  "description": "Improve the workflow on translate.wordpress.org",
+  "homepage_url": "https://github.com/Mte90/GlotDict",
+  "manifest_version": 2,
+  "icons": {
+    "48": "icons/icon-48.png",
+    "128": "icons/icon-128.png",
+    "16": "icons/icon-16.png"
+  },
+  "name": "GlotDict"
+}


### PR DESCRIPTION
What's changed in the manifest:
- Web-accessible resources
- Background service workers

I know it says [here](https://developer.chrome.com/docs/extensions/mv3/migrating_to_service_workers/#state) that this part in background.js



```
let gd_details = {};

chrome.runtime.onInstalled.addListener( ( details ) => {
	// 'install', 'update', 'chrome_update', or 'shared_module_update'
	gd_details = details;
	gd_details[ 'currentVersion' ] = chrome.runtime.getManifest().version;
} );

chrome.runtime.onMessage.addListener( ( request, sender, sendResponse ) => {
	if ( 'gd-status' === request ) {
		sendResponse( gd_details );
	}
} );
```
 is under 
```
// Don't do this! The service worker will be created and destroyed over the lifetime of your
// extension, and this variable will be reset.
```

but in practice it lives long enough for us to access it because we need to access it right after it was created and we don't need it anymore later when indeed it will be destroyed. `gd-status` request is a runtime request.

Testing this and it works. How to test:
1. Uninstall and install or bump version number and reload extension
2. Access a translation page
3. You should see the correct `What’s new in GlotDict x.x.x?` message

What if this doesn't work?

Well, the only thing that breaks would be the what's new feature. If this ends up being an issue in production we can come up with a fix, but it's not the desired fix, because it comes up with a new permission and this usually scares people (storage permission) - also I'm not sure it's justifiable for the reviewers. 

Fixes: #365 

 