### PR TITLE
Move the location of QuickLinks to acomodate new coming changes on w.org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 2.1.0
 * Enhancement: Add Discussion Quick Link.
+* Change: Move the location of QuickLinks to accomodate the upcoming changes on translate.w.org.
 
 # 2.0.11
 

--- a/css/style.css
+++ b/css/style.css
@@ -238,22 +238,6 @@ button.gd-approve strong {
     animation-name: gd-ripple-out;
 }
 
-.editor-panel__right .panel-header button {
-    background: none;
-    border: none;
-    height: 40px;
-    width: 40px;
-    padding: 0;
-    margin: 0;
-    vertical-align: middle;
-    box-shadow: none;
-    border-radius: 0;
-}
-
-.editor-panel__right .panel-header button:hover {
-    background: #fafafa;
-}
-
 .gd_quicklinks_copy.active {
     color: #0073aa;
 }

--- a/js/glotdict-consistency.js
+++ b/js/glotdict-consistency.js
@@ -61,7 +61,7 @@ function gd_quicklinks( current_editor = '.editor' ) {
 		gd_quicklinks_discussion,
 	);
 
-	gd_add_elements( `${current_editor} .editor-panel__right .panel-header`, 'beforeend', gd_quicklinks_output );
+	gd_add_elements( `${current_editor} .editor-panel__left .panel-header .panel-header-actions`, 'afterBegin', gd_quicklinks_output );
 
 	document.querySelectorAll( `${current_editor}` ).forEach( ( editor ) => {
 		const editor_menu = editor.querySelectorAll( '.button-menu__dropdown li a' );


### PR DESCRIPTION
New location to anticipate the changes on w.org

![image](https://user-images.githubusercontent.com/65488419/213880475-e7c314b9-c4ff-4274-b21e-e34017cf051a.png)


Fixes: #402 

Here's how translate.w.org will look:
https://github.com/GlotPress/gp-translation-helpers/pull/148

See screenshots in the issue.