### PR TITLE
Modified actions styles css to make them more compact and usable

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -39,6 +39,20 @@ table.translations tr.preview.has-original-copy,
     background: #e5f5fa;
 }
 
+/*
+using nth-child(6) instead of last-child ensures that the style 
+is not appied before action buttons are rendered
+*/
+@media screen and (min-width: 601px) {
+    table.translations > thead > tr > th:nth-child(6),
+    table.translations > tbody > tr > td:nth-child(6) {
+      width: 130px !important;
+      padding: 3px 0 3px 3px;
+      text-align: right;
+    }
+}
+
+
 .discard-glotdict {
     float: right;
 }
@@ -167,17 +181,37 @@ table.translations tr.preview.has-original-copy,
 }
 
 .actions+td button[class*="gd-"] strong {
-    display: inline-block;
-	margin-left:-10px;
+    font-size: 32px;
+    color: #fff;
+    line-height: 32px !important;
+    padding: 0 !important;
+    margin: -5px 0 0 !important;
+    display: block;
 }
 
 .actions+td button.gd-button{
 	-ms-flex-pack: center!important;
 	    justify-content: center!important;
-	padding: 14px 2px !important;
-	width: 80px !important;
-	margin: 1px 0 !important;
 	min-height: 28px !important;
+
+    display: inline-block;
+    font-size: 0;
+    width: 32px !important;
+    height: 32px !important;
+    text-align: center;
+    padding: 0 !important;
+    margin: 1px 3px 0 1px !important;
+    vertical-align: middle;
+}
+.actions+td button.gd-button.approve,
+.actions+td button.gd-button.approve:hover {
+  background-color: #46B450;
+}
+.actions+td button.gd-button.reject {
+  background-color: #DC3232;
+}
+.actions+td button.gd-button.fuzzy {
+  background-color: #f56e28;
 }
 
 .gd-btn-action {

--- a/css/style.css
+++ b/css/style.css
@@ -180,7 +180,8 @@ is not appied before action buttons are rendered
     border-left: 3px solid #dc3232;
 }
 
-.actions+td button[class*="gd-"] strong {
+.actions+td button[class*="gd-"] strong,
+.actions+td button .gd-btn-action {
     font-size: 32px;
     color: #fff;
     line-height: 32px !important;
@@ -189,7 +190,10 @@ is not appied before action buttons are rendered
     display: block;
 }
 
-.actions+td button.gd-button{
+.actions+td button.gd-button,
+.actions+td button.approve,
+.actions+td button.reject,
+.actions+td button.fuzzy {
 	-ms-flex-pack: center!important;
 	    justify-content: center!important;
 	min-height: 28px !important;
@@ -203,20 +207,23 @@ is not appied before action buttons are rendered
     margin: 1px 3px 0 1px !important;
     vertical-align: middle;
 }
-.actions+td button.gd-button.approve,
-.actions+td button.gd-button.approve:hover {
-  background-color: #46B450;
+.actions+td button.approve,
+.actions+td button.approve:hover {
+  background-color: #46B450 !important;
 }
-.actions+td button.gd-button.reject {
+.actions+td button.reject,
+.actions+td button.reject:hover {
   background-color: #DC3232;
 }
-.actions+td button.gd-button.fuzzy {
+.actions+td button.fuzzy,
+.actions+td button.fuzzy:hover {
   background-color: #f56e28;
 }
 
 .gd-btn-action {
     -webkit-animation: gd-rotation 2s infinite linear;
     animation: gd-rotation 2s infinite linear;
+    transform-origin: 50% 60%;
 }
 
 button.gd-approve strong {


### PR DESCRIPTION
This PR includes the CSS fixes I have been using for some time now via the "user CSS" Chrome extension.
It makes the quick action buttons more compact and usable.

The action buttons now look like these:
![image](https://github.com/user-attachments/assets/1d2d69fe-35f8-4b2d-bfbb-869dc7f2b57b)

I've already tested the changes installing my fork repo as a custom Chrome extension.